### PR TITLE
Add (broken) test for `get_definition()`

### DIFF
--- a/test/test_parser_tree.py
+++ b/test/test_parser_tree.py
@@ -149,3 +149,19 @@ def test_returns():
 
     r, = get_return_stmts('def x(): return 1')
     assert r.type == 'return_stmt'
+
+
+def test_get_definition_finds_definition_in_same_function(each_version):
+    code = dedent('''
+        def fun():
+            name = 1
+            bar = name + 1''')
+    module = parse(code, version=each_version)
+
+    # the first occurrence of name is also where it is defined
+    definition = module.get_name_of_position((3, 8)).get_definition()
+
+    # `name` occurs twice, both occurrences should have the same definition
+    # (which is the first occurrence.
+    assert [definition, definition] == [
+        o.get_definition() for o in module.get_used_names()['name']]


### PR DESCRIPTION
In a function like the following, parso fails to find the definition for
the second occurrence of `name`.

```python

    def fun():
        name = 1
        bar = name + 1

```

get_definition dutifully walks up the tree from `name + 1`, but bails when it gets to the `suite` (that I think represents the function body?) That means maybe the `suite` should return the definition in `get_defined_names()`, but I'm not sure that's enough, because if the lookup can't walk past this `suite` it could never find the function parameters as definitions, for instance... 