### PR TITLE
Use cPickle instead of pickle

### DIFF
--- a/parso/cache.py
+++ b/parso/cache.py
@@ -4,10 +4,14 @@ import sys
 import hashlib
 import gc
 import shutil
-import pickle
 import platform
 import errno
 import logging
+
+try:
+    import cPickle as pickle
+except:
+    import pickle
 
 from parso._compatibility import FileNotFoundError
 

--- a/parso/pgen2/grammar.py
+++ b/parso/pgen2/grammar.py
@@ -16,7 +16,10 @@ fallback token code OP, but the parser needs the actual token code.
 
 """
 
-import pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 
 
 class Grammar(object):


### PR DESCRIPTION
This PR change Parso to use cPickle instead of pickle when reading/writing the cache, which speeds up the cache significantly.

For people who are using Parso in Python 3, this probably won't have any impact, because in Python 3 when you `import pickle`, you are actually getting cPickle.

But for users of Python 2, this change has a huge impact — according to the docs, cPickle is up to 1000 times faster than pickle, and that is consistent with my own observations.

And in most installations, Vim's built-in Python interpreter is Python 2. Those facts combined mean that this change hugely speeds up jedi-vim.

I wrote this following the standard convention to get Python 2+3 compatibility:

```
try:
    import cPickle as pickle
except:
    import pickle
```