### PR TITLE
Load from cache even when code was given

### DIFF
--- a/parso/grammar.py
+++ b/parso/grammar.py
@@ -94,10 +94,7 @@ class Grammar(object):
         if error_recovery and start_symbol != 'file_input':
             raise NotImplementedError("This is currently not implemented.")
 
-        if cache and code is None and path is not None:
-            # With the current architecture we cannot load from cache if the
-            # code is given, because we just load from cache if it's not older than
-            # the latest change (file last modified).
+        if cache and path is not None:
             module_node = load_module(self._hashed, path, cache_path=cache_path)
             if module_node is not None:
                 return module_node


### PR DESCRIPTION
In debugging jedi-vim and jedi and parso to try to resolve some performance problems, I found that in many cases, the cache is not used. This change fixes that, but there would be other ways to fix this same issue, and I'm not sure if this is your preferred way to fix it.

Here's the issue. Suppose you type `import foo.` in vim. jedi-vim, jedi, and/or parso will then find all `.py` files in directory `foo`; read their contents into memory; and pass them to parso's `Grammar._parse()`. Both the `code` _and_ the `path` get passed in.

But `Grammar._parse()` has explicit code to see if `code` was passed in, and if it was, then not to try `load_module()`.

The result is that if directory `foo` has a lot of code, then code completion can take a very long time. In my case, in a codebase I work with, after typing the dot, I sometimes have to wait 10-15 seconds before I can continue typing.