### PR TITLE
Minor documentation fixups

### DIFF
--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -1062,7 +1062,7 @@ class Param(PythonBaseNode):
     @property
     def annotation(self):
         """
-        The default is the test node that appears after `->`. Is `None` in case
+        The default is the test node that appears after `:`. Is `None` in case
         no annotation is present.
         """
         tfpdef = self._tfpdef()

--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -97,7 +97,7 @@ class PythonMixin(object):
 
     def get_name_of_position(self, position):
         """
-        Given a (line, column) tuple, returns a :class`Name` or ``None`` if
+        Given a (line, column) tuple, returns a :py:class:`Name` or ``None`` if
         there is no name at that position.
         """
         for c in self.children:

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -278,6 +278,14 @@ class BaseNode(NodeOrLeaf):
         return self._get_code_for_children(self.children, include_prefix)
 
     def get_leaf_for_position(self, position, include_prefixes=False):
+        """
+        Get the :py:class:`parso.tree.Leaf` at ``position``
+
+        :param tuple position: A position tuple, row, column. Rows start from 1
+        :param bool include_prefixes: If ``False``, ``None`` will be returned if ``position`` falls
+            on whitespace before a leaf
+        :return: :py:class:`parso.tree.Leaf` at ``position``, or ``None``
+        """
         def binary_search(lower, upper):
             if lower == upper:
                 element = self.children[lower]

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -283,7 +283,7 @@ class BaseNode(NodeOrLeaf):
 
         :param tuple position: A position tuple, row, column. Rows start from 1
         :param bool include_prefixes: If ``False``, ``None`` will be returned if ``position`` falls
-            on whitespace before a leaf
+            on whitespace or comments before a leaf
         :return: :py:class:`parso.tree.Leaf` at ``position``, or ``None``
         """
         def binary_search(lower, upper):


### PR DESCRIPTION
I'm working on https://github.com/robodair/pydocstring to use parso instead of regex, and hoped to clear up a few bits and pieces of the parso docs while I'm at it.