### PR TITLE
Support async for statement

### DIFF
--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -1161,4 +1161,5 @@ class CompFor(PythonBaseNode):
         """
         Returns the a list of `Name` that the comprehension defines.
         """
-        return _defined_names(self.children[1])
+        # allow async for
+        return _defined_names(self.children[self.children.index('for') + 1])


### PR DESCRIPTION
Generate correct definitions for 
`a = [func(x) async for x in foo()]`

Otherwise `x` will not be defined in the `func(x)` context.