### PR TITLE
Fix typos

### DIFF
--- a/parso/grammar.py
+++ b/parso/grammar.py
@@ -73,7 +73,7 @@ class Grammar(object):
             :py:class:`parso.python.tree.Module`.
         """
         if 'start_pos' in kwargs:
-            raise TypeError("parse() got an unexpected keyworda argument.")
+            raise TypeError("parse() got an unexpected keyword argument.")
         return self._parse(code=code, **kwargs)
 
     def _parse(self, code=None, error_recovery=True, path=None,

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -55,7 +55,6 @@ class NodeOrLeaf(object):
         Returns the node immediately preceding this node in this parent's
         children list. If this node does not have a previous sibling, it is
         None.
-        None.
         """
         # Can't use index(); we need to test by identity
         for i, child in enumerate(self.parent.children):


### PR DESCRIPTION
Just a trifling typo but better to be fixed.
* keyworda → keyword [parso/grammar.py]
* delete accidentally repeated `None.` [parso/tree.py]
