### PR TITLE
tox: use older pytest only for py26/py33

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,14 @@
 envlist = py26, py27, py33, py34, py35, py36
 [testenv]
 deps =
-    pytest>=3.0.7, < 3.3
+    {env:_PARSO_TEST_PYTEST_DEP:pytest>=3.0.7}
 # For --lf and --ff.
     pytest-cache
 setenv =
 # https://github.com/tomchristie/django-rest-framework/issues/1957
 # tox corrupts __pycache__, solution from here:
     PYTHONDONTWRITEBYTECODE=1
+    py26,py33: _PARSO_TEST_PYTEST_DEP=pytest>=3.0.7,<3.3
 commands =
     pytest {posargs:parso test}
 [testenv:cov]


### PR DESCRIPTION
Follow-up to https://github.com/davidhalter/parso/commit/73439d5863daea.