### PR TITLE
Added mutmut to "used by" section of the docs

### DIFF
--- a/docs/docs/usage.rst
+++ b/docs/docs/usage.rst
@@ -61,6 +61,8 @@ Used By
 -------
 
 - jedi_ (which is used by IPython and a lot of editor plugins).
+- mutmut_ (mutation tester)
 
 
 .. _jedi: https://github.com/davidhalter/jedi
+.. _mutmut: https://github.com/boxed/mutmut


### PR DESCRIPTION
Mutmut used to use baron but it's pretty much unmaintained. Moving to parso actually simplified my code quite a bit in addition to getting full python 3 support. So great and thank you a lot for this library!