### PR TITLE
Fix order nondeterminism in DFA state generation.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,6 +6,7 @@ David Halter (@davidhalter) <davidhalter88@gmail.com>
 Code Contributors
 =================
 Alisdair Robertson (@robodair)
+Jennifer Taylor (@dragonminded)
 
 
 Code Contributors (to Jedi and therefore possibly to this library)

--- a/parso/pgen2/generator.py
+++ b/parso/pgen2/generator.py
@@ -71,7 +71,7 @@ class DFAState(object):
     different nonterminals.
     """
     def __init__(self, from_rule, nfa_set, final):
-        assert isinstance(nfa_set, set)
+        assert isinstance(nfa_set, (set, list))
         assert isinstance(next(iter(nfa_set)), NFAState)
         assert isinstance(final, NFAState)
         self.from_rule = from_rule
@@ -174,12 +174,12 @@ def _make_dfas(start, finish):
         assert isinstance(nfa_state, NFAState)
         if nfa_state in base_nfa_set:
             return
-        base_nfa_set.add(nfa_state)
+        base_nfa_set.insert(0, nfa_state)
         for nfa_arc in nfa_state.arcs:
             if nfa_arc.nonterminal_or_string is None:
                 addclosure(nfa_arc.next, base_nfa_set)
 
-    base_nfa_set = set()
+    base_nfa_set = []
     addclosure(start, base_nfa_set)
     states = [DFAState(start.from_rule, base_nfa_set, finish)]
     for state in states:  # NB states grows while we're iterating
@@ -188,7 +188,7 @@ def _make_dfas(start, finish):
         for nfa_state in state.nfa_set:
             for nfa_arc in nfa_state.arcs:
                 if nfa_arc.nonterminal_or_string is not None:
-                    nfa_set = arcs.setdefault(nfa_arc.nonterminal_or_string, set())
+                    nfa_set = arcs.setdefault(nfa_arc.nonterminal_or_string, [])
                     addclosure(nfa_arc.next, nfa_set)
 
         # Now create the dfa's with no None's in arcs anymore. All Nones have


### PR DESCRIPTION
Set traversal is unfortunately still non-deterministic in Python 3.6. This fixes non-deterministically choosing the wrong production in some cases when using a custom grammar with parso. I don't see the incorrect behavior with Python's default grammar however. This looks like it is probably a slight speed regression due to membership checking on list instead of set. I'm not sure if that's a problem in practice, however? Passes all tests that were passing pre-change in Py 2.7, 3.3 and 3.6.