### PR TITLE
Fix line continuation characters inside f-strings

### DIFF
--- a/parso/python/tokenize.py
+++ b/parso/python/tokenize.py
@@ -118,9 +118,9 @@ def _get_token_collection(version_info):
         return result
 
 
-fstring_string_single_line = _compile(r'(?:[^{}\r\n]+|\{\{|\}\})+')
+fstring_string_single_line = _compile(r'(?:\{\{|\}\}|\\(?:\r\n?|\n)|[^{}\r\n])+')
 fstring_string_multi_line = _compile(r'(?:[^{}]+|\{\{|\}\})+')
-fstring_format_spec_single_line = _compile(r'[^{}\r\n]+')
+fstring_format_spec_single_line = _compile(r'(?:\\(?:\r\n?|\n)|[^{}\r\n])+')
 fstring_format_spec_multi_line = _compile(r'[^{}]+')
 
 
@@ -340,7 +340,9 @@ def _find_fstring_string(endpats, fstring_stack, line, lnum, pos):
 
     new_pos = pos
     new_pos += len(string)
-    if allow_multiline and (string.endswith('\n') or string.endswith('\r')):
+    # even if allow_multiline is False, we still need to check for trailing
+    # newlines, because a single-line f-string can contain line continuations
+    if string.endswith('\n') or string.endswith('\r'):
         tos.previous_lines += string
         string = ''
     else:


### PR DESCRIPTION
Line continuation characters are valid inside of strings, but weren't handled correctly in certain cases with f-strings, due to some small tokenizer bugs.

This pull request to address those issues, and adds tests to validate the new logic.

### Before

```
>>> from parso import *
>>> parse('f"abc\\\ndef"', error_recovery=False).children
Traceback (most recent call last):
  File "/home/bgw/parso/parso/parser.py", line 181, in _add_token
    plan = stack[-1].dfa.transitions[transition]
KeyError: TokenType(NEWLINE)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/bgw/parso/parso/__init__.py", line 58, in parse
    return grammar.parse(code, **kwargs)
  File "/home/bgw/parso/parso/grammar.py", line 78, in parse
    return self._parse(code=code, **kwargs)
  File "/home/bgw/parso/parso/grammar.py", line 147, in _parse
    root_node = p.parse(tokens=tokens)
  File "/home/bgw/parso/parso/python/parser.py", line 82, in parse
    return super(Parser, self).parse(tokens)
  File "/home/bgw/parso/parso/parser.py", line 128, in parse
    self._add_token(token)
  File "/home/bgw/parso/parso/parser.py", line 187, in _add_token
    self.error_recovery(token)
  File "/home/bgw/parso/parso/python/parser.py", line 151, in error_recovery
    return super(Parser, self).error_recovery(token)
  File "/home/bgw/parso/parso/parser.py", line 151, in error_recovery
    raise ParserSyntaxError('SyntaxError: invalid syntax', error_leaf)
parso.parser.ParserSyntaxError: ('SyntaxError: invalid syntax', <ErrorLeaf: TokenType(NEWLINE):'\n', (1, 6)>)
```

### After

```
>>> from parso import *
>>> parse('f"abc\\\ndef"', error_recovery=False).children
[PythonNode(fstring, [<FStringStart: f">, <FStringString: abc\
def>, <FStringEnd: ">]), <EndMarker: prefix='' end_pos=(2, 4)>]
```

---

cc @DragonMinded, @rayjzeng, @carljm