### PR TITLE
Remove debug print statement in errors.py

### DIFF
--- a/parso/python/errors.py
+++ b/parso/python/errors.py
@@ -959,7 +959,6 @@ class _CompForRule(_CheckAssignmentRule):
 
     def is_issue(self, node):
         expr_list = node.children[1]
-        print(expr_list)
         if expr_list.type != 'expr_list':  # Already handled.
             self._check_assignment(expr_list)
 


### PR DESCRIPTION
I'm thinking this `print` wasn't left here on purpose 🤔 

It looks like this
```
<Name: ingestion_date@823,39>
<Name: ingestion_date@824,51>
<Name: date@827,58>
<Name: date@828,75>
<Name: ingestion_date@883,39>
<Name: ingestion_date@884,51>
<Name: date@887,58>
<Name: date@888,85>
<Name: path@1039,33>
<Name: ingestion_date@823,39>
<Name: ingestion_date@824,51>
<Name: date@827,58>
<Name: date@828,75>
<Name: ingestion_date@883,39>
<Name: ingestion_date@884,51>
<Name: date@887,58>
<Name: date@888,85>
<Name: path@1039,33>
```

