### PR TITLE
Fixing davidhalter/parso#89

### DIFF
--- a/test/failing_examples.py
+++ b/test/failing_examples.py
@@ -319,3 +319,25 @@ if sys.version_info[:2] < (3, 8):
                     continue
             '''),  # 'continue' not supported inside 'finally' clause"
     ]
+
+if sys.version_info[:2] >= (3, 8):
+    # assignment expressions from issue#89
+    FAILING_EXAMPLES += [
+        # Case 2
+        '(lambda: x := 1)',
+        # Case 3
+        '(a[i] := x)',
+        # Case 4
+        '(a.b := c)',
+        # Case 5
+        '[i:= 0 for i, j in range(5)]',
+        '[[(i:= i) for j in range(5)] for i in range(5)]',
+        '[i for i, j in range(5) if True or (i:= 1)]',
+        '[False and (i:= 0) for i, j in range(5)]',
+        # Case 6
+        '[i+1 for i in (i:= range(5))]',
+        '[i+1 for i in (j:= range(5))]',
+        '[i+1 for i in (lambda: (j:= range(5)))()]',
+        # Case 7
+        'class Example:\n [(j := i) for i in range(5)]',
+    ]

--- a/test/test_python_errors.py
+++ b/test/test_python_errors.py
@@ -294,6 +294,19 @@ def test_valid_fstrings(code):
 
 
 @pytest.mark.parametrize(
+    'code', [
+        'a = (b := 1)',
+        '[x4 := x ** 5 for x in range(7)]',
+        '[total := total + v for v in range(10)]',
+        'while chunk := file.read(2):\n pass',
+        'numbers = [y := math.factorial(x), y**2, y**3]',
+    ]
+)
+def test_valid_namedexpr(code):
+    assert not _get_error_list(code, version='3.8')
+
+
+@pytest.mark.parametrize(
     ('code', 'message'), [
         ("f'{1+}'", ('invalid syntax')),
         (r'f"\"', ('invalid syntax')),


### PR DESCRIPTION
> all changes are in `parso/python/errors.py`

* add utility function (`_get_namedexpr`) to extract all assignment expression (`namedexpr_test`) nodes
* add `is_namedexpr` parameter to `_CheckAssignmentRule._check_assignment` and special error message for assignment expression related assignment issues (*cannot use named assignment with xxx*)
* add assignment expression check to `_CompForRule` (*assignment expression cannot be used in a comprehension iterable expression*)
* add `_NamedExprRule` for special assignment expression checks
  - *cannot use named assignment with lambda*
  - *cannot use named assignment with subscript*
  - *cannot use named assignment with attribute*
  - and fallback general checks in `_CheckAssignmentRule._check_assignment`
* add `_ComprehensionRule` for special checks on assignment expression in a comprehension
  - *assignment expression within a comprehension cannot be used in a class body*
  - *assignment expression cannot rebind comprehension iteration variable 'xxx'*

Sample testing code:

```python
import parso

grammar = parso.load_grammar(version='3.8')

string = '''\
# Case 2
(lambda: x := 1)
# Case 3
(a[i] := x)
# Case 4
(a.b := c)
# Case 5
[i := 0 for i, j in range(5)]
[[(i := i) for j in range(5)] for i in range(5)]
[i for i, j in range(5) if True or (i := 1)]
[False and (i := 0) for i, j in range(5)]
# Case 6
[i+1 for i in (i := range(5))]
[i+1 for i in (j := range(5))]
[i+1 for i in (lambda: (j := range(5)))()]
# Case 7
class Example:
    [(j := i) for i in range(5)]
'''
module = grammar.parse(string, error_recovery=True)

errors = grammar.iter_errors(module)
print('\n'.join('[L%dC%d] %s' % (*error.start_pos, error.message) for error in errors))
```

Sample output:

```pytb
[L2C1] SyntaxError: cannot use named assignment with lambda
[L4C1] SyntaxError: cannot use named assignment with subscript
[L6C1] SyntaxError: cannot use named assignment with attribute
[L8C1] SyntaxError: assignment expression cannot rebind comprehension iteration variable 'i'
[L9C3] SyntaxError: assignment expression cannot rebind comprehension iteration variable 'i'
[L10C36] SyntaxError: assignment expression cannot rebind comprehension iteration variable 'i'
[L11C12] SyntaxError: assignment expression cannot rebind comprehension iteration variable 'i'
[L13C15] SyntaxError: assignment expression cannot be used in a comprehension iterable expression
[L14C15] SyntaxError: assignment expression cannot be used in a comprehension iterable expression
[L15C24] SyntaxError: assignment expression cannot be used in a comprehension iterable expression
[L18C6] SyntaxError: assignment expression within a comprehension cannot be used in a class body
```