### PR TITLE
Add venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ parso.egg-info/
 /.cache/
 /.pytest_cache
 test/fuzz-redo.pickle
+/venv/


### PR DESCRIPTION
Similar to my [commit to `jedi` of a similar form.](https://github.com/davidhalter/jedi/commit/d42d3f45f08e06f3893e6e948c332cc0e52a2ca9)

For Github contributions to different libraries, I like keeping different Python `virtualenv`'s.  `venv` is the most common name for such a directory, so proactively `.gitignore` it.