### PR TITLE
approve hit msg when python version is unsupported

### DIFF
--- a/parso/grammar.py
+++ b/parso/grammar.py
@@ -252,7 +252,7 @@ def load_grammar(**kwargs):
                     grammar = PythonGrammar(version_info, bnf_text)
                     return _loaded_grammars.setdefault(path, grammar)
                 except FileNotFoundError:
-                    message = "Python version %s is currently not supported." % version
+                    message = "Python version %s.%s is currently not supported." % (version_info.major, version_info.minor)
                     raise NotImplementedError(message)
         else:
             raise NotImplementedError("No support for language %s." % language)


### PR DESCRIPTION
currently, when the python version used is not supported, it will raise "Python version None is currently not supported.". 

Maybe it could be changed to raise NotImplement("Python version x.x is currently not supported")