### PR TITLE
Correctly parse 2-digit minor versions (py3.10)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -50,6 +50,7 @@ Daniel Fiterman (@dfit99) <fitermandaniel2@gmail.com>
 Simon Ruggier (@sruggier)
 Élie Gouzien (@ElieGouzien)
 Tim Gates (@timgates42) <tim.gates@iress.com>
+Batuhan Taskaya (@isidentical) <isidentical@gmail.com>
 
 
 Note: (@user) means a github user name.

--- a/parso/utils.py
+++ b/parso/utils.py
@@ -129,7 +129,7 @@ def version_info():
 
 
 def _parse_version(version):
-    match = re.match(r'(\d+)(?:\.(\d)(?:\.\d+)?)?$', version)
+    match = re.match(r'(\d+)(?:\.(\d{1,2})(?:\.\d+)?)?$', version)
     if match is None:
         raise ValueError('The given version is not in the right format. '
                          'Use something like "3.8" or "3".')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,11 @@
 from codecs import BOM_UTF8
 
-from parso.utils import split_lines, python_bytes_to_unicode
+from parso.utils import (
+    split_lines,
+    parse_version_string,
+    python_bytes_to_unicode,
+)
+
 import parso
 
 import pytest
@@ -77,3 +82,18 @@ def test_bytes_to_unicode_failing_encoding(code, errors):
             python_bytes_to_unicode(code, errors=errors)
     else:
         python_bytes_to_unicode(code, errors=errors)
+
+@pytest.mark.parametrize(
+    ('version_str', 'version'), [
+        ('3', (3,)),
+        ('3.6', (3, 6)),
+        ('3.6.10', (3, 6)),
+        ('3.10', (3, 10)),
+    ]
+)
+def test_parse_version_string(version_str, version):
+    parsed_version = parse_version_string(version_str)
+    if len(version) == 1:
+        assert parsed_version[0] == version[0]
+    else:
+        assert parsed_version == version


### PR DESCRIPTION
With the release of py3.10, parso started to fail parsing it's version number
```
Traceback (most recent call last):
  File "/home/isidentical/syntax_test_suite/unimportz.py", line 11, in <module>
    from unimport.session import Session
  File "/home/isidentical/.venvs/master/lib/python3.10/site-packages/unimport/session.py", line 7, in <module>
    from unimport.refactor import refactor_string
  File "/home/isidentical/.venvs/master/lib/python3.10/site-packages/unimport/refactor.py", line 1, in <module>
    import libcst as cst
  File "/home/isidentical/.venvs/master/lib/python3.10/site-packages/libcst/__init__.py", line 187, in <module>
    from libcst._parser.entrypoints import parse_expression, parse_module, parse_statement
  File "/home/isidentical/.venvs/master/lib/python3.10/site-packages/libcst/_parser/entrypoints.py", line 25, in <module>
    _DEFAULT_PARTIAL_PARSER_CONFIG: PartialParserConfig = PartialParserConfig()
  File "<string>", line 8, in __init__
  File "/home/isidentical/.venvs/master/lib/python3.10/site-packages/libcst/_parser/types/config.py", line 121, in __post_init__
    parsed_python_version = parse_version_string(
  File "/home/isidentical/.venvs/master/lib/python3.10/site-packages/libcst/_parser/parso/utils.py", line 218, in parse_version_string
    return _parse_version(version)
  File "/home/isidentical/.venvs/master/lib/python3.10/site-packages/libcst/_parser/parso/utils.py", line 187, in _parse_version
    raise ValueError(
ValueError: The given version is not in the right format. Use something like "3.2" or "3".
```