### PR TITLE
Allow 'any' expression on decorators, PEP 614

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -163,3 +163,8 @@ def works_ge_py35(each_version):
 def works_ge_py38(each_version):
     version_info = parse_version_string(each_version)
     return Checker(each_version, version_info >= (3, 8))
+
+@pytest.fixture
+def works_ge_py39(each_version):
+    version_info = parse_version_string(each_version)
+    return Checker(each_version, version_info >= (3, 9))

--- a/parso/python/grammar39.txt
+++ b/parso/python/grammar39.txt
@@ -12,7 +12,7 @@ single_input: NEWLINE | simple_stmt | compound_stmt NEWLINE
 file_input: stmt* ENDMARKER
 eval_input: testlist NEWLINE* ENDMARKER
 
-decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE
+decorator: '@' namedexpr_test NEWLINE
 decorators: decorator+
 decorated: decorators (classdef | funcdef | async_funcdef)
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -208,3 +208,13 @@ def test_named_expression(works_ge_py38):
 )
 def test_positional_only_arguments(works_ge_py38, param_code):
     works_ge_py38.parse("def x(%s): pass" % param_code)
+
+@pytest.mark.parametrize(
+    'expression', [
+        'a + a',
+        'lambda x: x',
+        'a := lambda x: x'
+    ]
+)
+def test_decorator_expression(works_ge_py39, expression):
+    works_ge_py39.parse("@%s\ndef x(): pass" % expression)


### PR DESCRIPTION
PEP 614 (implemented with 3.9) now allows any expression on decorators https://www.python.org/dev/peps/pep-0614/