### PR TITLE
Check all arguments for unparenthesized generator expressions

### DIFF
--- a/parso/python/errors.py
+++ b/parso/python/errors.py
@@ -800,9 +800,18 @@ class _ArglistRule(SyntaxRule):
 
             if argument.type == 'argument':
                 first = argument.children[0]
-                if argument.children[1].type in _COMP_FOR_TYPES and len(node.children) >= 2:
-                    # a(a, b for b in c)
-                    return True
+                if (
+                    argument.children[1].type in _COMP_FOR_TYPES
+                    and len(node.children) >= 2
+                ):
+                    if self._normalizer.version >= (3, 7):
+                        return True
+                    elif len(node.children) == 2 and node.children[1] == ",":
+                        # trailing comma allowed until 3.7
+                        pass
+                    else:
+                        return True
+
                 if first in ('*', '**'):
                     if first == '*':
                         if kw_unpacking_only:

--- a/parso/python/errors.py
+++ b/parso/python/errors.py
@@ -800,18 +800,9 @@ class _ArglistRule(SyntaxRule):
 
             if argument.type == 'argument':
                 first = argument.children[0]
-                if (
-                    argument.children[1].type in _COMP_FOR_TYPES
-                    and len(node.children) >= 2
-                ):
-                    if self._normalizer.version >= (3, 7):
-                        return True
-                    elif len(node.children) == 2 and node.children[1] == ",":
-                        # trailing comma allowed until 3.7
-                        pass
-                    else:
-                        return True
-
+                if argument.children[1].type in _COMP_FOR_TYPES and len(node.children) >= 2:
+                    # a(a, b for b in c)
+                    return True
                 if first in ('*', '**'):
                     if first == '*':
                         if kw_unpacking_only:

--- a/test/test_python_errors.py
+++ b/test/test_python_errors.py
@@ -378,17 +378,16 @@ def test_repeated_kwarg():
 
 
 @pytest.mark.parametrize(
-    ('source', 'no_errors', 'version'), [
-        ('a(a for a in b,)', True, '3.6'),
-        ('a(a for a in b,)', False, '3.7'),
-        ('a(a for a in b, a)', False, None),
-        ('a(a, a for a in b)', False, None),
-        ('a(a, b, a for a in b, c, d)', False, None),
-        ('a(a for a in b)', True, None),
-        ('a((a for a in b), c)', True, None),
-        ('a(c, (a for a in b))', True, None),
-        ('a(a, (a for a in b), c)', True, None),
+    ('source', 'no_errors'), [
+        ('a(a for a in b,)', False),
+        ('a(a for a in b, a)', False),
+        ('a(a, a for a in b)', False),
+        ('a(a, b, a for a in b, c, d)', False),
+        ('a(a for a in b)', True),
+        ('a((a for a in b), c)', True),
+        ('a(c, (a for a in b))', True),
+        ('a(a, b, (a for a in b), c, d)', True),
     ]
 )
-def test_unparenthesized_genexp(source, no_errors, version):
-    assert bool(_get_error_list(source, version=version)) ^ no_errors
+def test_unparenthesized_genexp(source, no_errors):
+    assert bool(_get_error_list(source)) ^ no_errors

--- a/test/test_python_errors.py
+++ b/test/test_python_errors.py
@@ -378,12 +378,17 @@ def test_repeated_kwarg():
 
 
 @pytest.mark.parametrize(
-    'source', [
-        'a(a for a in b,)'
-        'a(a for a in b, a)',
-        'a(a, a for a in b)',
-        'a(a, b, a for a in b, c, d)',
+    ('source', 'no_errors', 'version'), [
+        ('a(a for a in b,)', True, '3.6'),
+        ('a(a for a in b,)', False, '3.7'),
+        ('a(a for a in b, a)', False, None),
+        ('a(a, a for a in b)', False, None),
+        ('a(a, b, a for a in b, c, d)', False, None),
+        ('a(a for a in b)', True, None),
+        ('a((a for a in b), c)', True, None),
+        ('a(c, (a for a in b))', True, None),
+        ('a(a, (a for a in b), c)', True, None),
     ]
 )
-def test_unparenthesized_genexp(source):
-    assert _get_error_list(source)
+def test_unparenthesized_genexp(source, no_errors, version):
+    assert bool(_get_error_list(source, version=version)) ^ no_errors

--- a/test/test_python_errors.py
+++ b/test/test_python_errors.py
@@ -375,3 +375,15 @@ def test_repeated_kwarg():
         _get_error_list("f(q=1, q=2)", version="3.9")[0].message
         == "SyntaxError: keyword argument repeated: q"
     )
+
+
+@pytest.mark.parametrize(
+    'source', [
+        'a(a for a in b,)'
+        'a(a for a in b, a)',
+        'a(a, a for a in b)',
+        'a(a, b, a for a in b, c, d)',
+    ]
+)
+def test_unparenthesized_genexp(source):
+    assert _get_error_list(source)


### PR DESCRIPTION
Previously only the first argument on the argument list checked
against the generator expressions, now all argumnets are controlled.