### PR TITLE
Clear inactive cache files

### DIFF
--- a/parso/_compatibility.py
+++ b/parso/_compatibility.py
@@ -2,6 +2,7 @@
 To ensure compatibility from Python ``2.7`` - ``3.3``, a module has been
 created. Clearly there is huge need to use conforming syntax.
 """
+import os
 import sys
 import platform
 
@@ -44,11 +45,11 @@ def u(string):
 
 
 try:
-    # Python 2.7
+    # Python 3.3+
     FileNotFoundError = FileNotFoundError
 except NameError:
-    # Python 3.3+
-    FileNotFoundError = IOError
+    # Python 2.7 (both IOError + OSError)
+    FileNotFoundError = EnvironmentError
 
 
 def utf8_repr(func):
@@ -67,3 +68,27 @@ def utf8_repr(func):
         return func
     else:
         return wrapper
+
+if sys.version_info < (3, 5):
+    """
+    A super-minimal shim around listdir that behave like
+    scandir for the information we need.
+    """
+    class _DirEntry:
+
+        def __init__(self, name, basepath):
+            self.name = name
+            self.basepath = basepath
+
+        @property
+        def path(self):
+            return os.path.join(self.basepath, self.name)
+
+        def stat(self):
+            # won't follow symlinks
+            return os.lstat(os.path.join(self.basepath, self.name))
+
+    def scandir(dir):
+        return [_DirEntry(name, dir) for name in os.listdir(dir)]
+else:
+    from os import scandir

--- a/parso/cache.py
+++ b/parso/cache.py
@@ -13,7 +13,8 @@ try:
 except:
     import pickle
 
-from parso._compatibility import FileNotFoundError
+from parso._compatibility import FileNotFoundError, scandir
+from parso.file_io import FileIO
 
 LOG = logging.getLogger(__name__)
 
@@ -21,6 +22,13 @@ _CACHED_FILE_MINIMUM_SURVIVAL = 60 * 10  # 10 minutes
 """
 Cached files should survive at least a few minutes.
 """
+
+_CACHED_FILE_MAXIMUM_SURVIVAL = 60 * 60 * 24 * 30
+"""
+Maximum time for a cached file to survive if it is not
+accessed within.
+"""
+
 _CACHED_SIZE_TRIGGER = 600
 """
 This setting limits the amount of cached files. It's basically a way to start
@@ -81,6 +89,20 @@ On Linux, this defaults to ``~/.cache/parso/``, on OS X to
 On Linux, if environment variable ``$XDG_CACHE_HOME`` is set,
 ``$XDG_CACHE_HOME/parso`` is used instead of the default one.
 """
+
+_CACHE_CLEAR_THRESHOLD = 60 * 60 * 24
+
+def _get_cache_clear_lock(cache_path = None):
+    """
+    The path where the cache lock is stored.
+
+    Cache lock will prevent continous cache clearing and only allow garbage
+    collection once a day (can be configured in _CACHE_CLEAR_THRESHOLD).
+    """
+    cache_path = cache_path or _get_default_cache_path()
+
+    return FileIO(os.path.join(cache_path, "{}-cache-lock".format(_VERSION_TAG)))
+
 
 parser_cache = {}
 
@@ -173,6 +195,7 @@ def save_module(hashed_grammar, file_io, module, lines, pickling=True, cache_pat
     _set_cache_item(hashed_grammar, path, item)
     if pickling and path is not None:
         _save_to_file_system(hashed_grammar, path, item, cache_path=cache_path)
+        _remove_cache_and_update_lock(cache_path = cache_path)
 
 
 def _save_to_file_system(hashed_grammar, path, item, cache_path=None):
@@ -186,6 +209,37 @@ def clear_cache(cache_path=None):
     shutil.rmtree(cache_path)
     parser_cache.clear()
 
+
+def clear_inactive_cache(
+    cache_path=None,
+    inactivity_threshold=_CACHED_FILE_MAXIMUM_SURVIVAL,
+):
+    cache_path = _get_default_cache_path()
+    if not os.path.exists(cache_path):
+        return False
+    for version_path in os.listdir(cache_path):
+        version_path = os.path.join(cache_path, version_path)
+        if not os.path.isdir(version_path):
+            continue
+        for file in scandir(version_path):
+            if (
+                file.stat().st_atime + _CACHED_FILE_MAXIMUM_SURVIVAL
+                <= time.time()
+            ):
+                os.remove(file.path)
+    else:
+        return True
+
+
+def _remove_cache_and_update_lock(cache_path = None):
+    lock = _get_cache_clear_lock(cache_path=cache_path)
+    clear_lock_time = lock.get_last_modified()
+    if (
+        clear_lock_time is None # first time
+        or clear_lock_time + _CACHE_CLEAR_THRESHOLD <= time.time()
+    ):
+        if clear_inactive_cache(cache_path = cache_path):
+            lock._touch()
 
 def _get_hashed_path(hashed_grammar, path, cache_path=None):
     directory = _get_cache_directory_path(cache_path=cache_path)

--- a/parso/file_io.py
+++ b/parso/file_io.py
@@ -27,8 +27,12 @@ class FileIO(object):
         try:
             os.utime(self.path, None)
         except FileNotFoundError:
-            file = open(self.path, 'a')
-            file.close()
+            try:
+                file = open(self.path, 'a')
+                file.close()
+            except (OSError, IOError):  # TODO Maybe log this?
+                return False
+        return True
 
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, self.path)

--- a/parso/file_io.py
+++ b/parso/file_io.py
@@ -1,4 +1,5 @@
 import os
+from parso._compatibility import FileNotFoundError
 
 
 class FileIO(object):
@@ -21,6 +22,13 @@ class FileIO(object):
         except OSError:
             # Might raise FileNotFoundError, OSError for Python 2
             return None
+
+    def _touch(self):
+        try:
+            os.utime(self.path, None)
+        except FileNotFoundError:
+            file = open(self.path, 'a')
+            file.close()
 
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, self.path)


### PR DESCRIPTION
Cache files that weren't accessed in the last 30 days will be automatically
garbage collected. This collection happens when the `save_module` is called
via a lock system that would make it happen only one time per day. Resolves #120 