### PR TITLE
Fix #139: newlines in async for comprehension

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -51,6 +51,7 @@ Simon Ruggier (@sruggier)
 Élie Gouzien (@ElieGouzien)
 Tim Gates (@timgates42) <tim.gates@iress.com>
 Batuhan Taskaya (@isidentical) <isidentical@gmail.com>
+Jocelyn Boullier (@Kazy) <jocelyn@boullier.bzh>
 
 
 Note: (@user) means a github user name.

--- a/conftest.py
+++ b/conftest.py
@@ -158,6 +158,10 @@ def works_ge_py35(each_version):
     version_info = parse_version_string(each_version)
     return Checker(each_version, version_info >= (3, 5))
 
+@pytest.fixture
+def works_ge_py36(each_version):
+    version_info = parse_version_string(each_version)
+    return Checker(each_version, version_info >= (3, 6))
 
 @pytest.fixture
 def works_ge_py38(each_version):

--- a/parso/python/tokenize.py
+++ b/parso/python/tokenize.py
@@ -260,7 +260,7 @@ def _create_token_collection(version_info):
                            'finally', 'while', 'with', 'return', 'continue',
                            'break', 'del', 'pass', 'global', 'assert')
     if version_info >= (3, 5):
-        ALWAYS_BREAK_TOKENS += ('async', 'nonlocal')
+        ALWAYS_BREAK_TOKENS += ('nonlocal', )
     pseudo_token_compiled = _compile(PseudoToken)
     return TokenCollection(
         pseudo_token_compiled, single_quoted, triple_quoted, endpats,

--- a/test/test_pgen2.py
+++ b/test/test_pgen2.py
@@ -87,6 +87,39 @@ def test_async_for(works_ge_py35):
     works_ge_py35.parse("async def foo():\n async for a in b: pass")
 
 
+@pytest.mark.parametrize("body", [
+    """[1 async for a in b
+    ]""",
+    """[1 async
+    for a in b
+    ]""",
+    """[
+    1
+    async for a in b
+    ]""",
+    """[
+    1
+    async for a
+    in b
+    ]""",
+    """[
+    1
+    async
+    for
+    a
+    in
+    b
+    ]""",
+    """  [
+    1 async for a in b
+  ]""",
+])
+def test_async_for_comprehension_newline(works_ge_py36, body):
+    # Issue #139
+    works_ge_py36.parse("""async def foo():
+    {}""".format(body))
+
+
 def test_async_with(works_ge_py35):
     works_ge_py35.parse("async def foo():\n async with a: pass")
 


### PR DESCRIPTION
I decided to take a stab at this. I don't know if this is the right fix, and if the test is the right place (should it be in `test_tokenize.py` ?).

I traced back the difference between the parsing of a for comprehension and an async one to the tokenization. In a normal for-comprehension, the `]` token has `\n     ` as a prefix, while in the case of `async for` it has `NEWLINE` token which isn't part of the DFA transitions and is thus a `SyntaxError`.

Removing `async` from the `ALWAYS_BREAK_TOKENS` fixes this, all the tests are passing. I don't know if this can have consequences in other uses of `async`. Codes like this are still rejected:
```python
async
def foo():
   ....

# or
async
    def foo():
        ...
```

Now it also correctly parses all possible insertion of newlines in the async for-comprehension, just like a sync one.
```python
async def foo():
    [1 
    async
    for
    _
    in
    range(5)
    ]
```
