### PR TITLE
Let consumers know that we have type annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='parso',
       keywords='python parser parsing',
       long_description=readme,
       packages=find_packages(exclude=['test']),
-      package_data={'parso': ['python/grammar*.txt']},
+      package_data={'parso': ['python/grammar*.txt', 'py.typed', '*.pyi', '**/*.pyi']},
       platforms=['any'],
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       classifiers=[
@@ -44,6 +44,7 @@ setup(name='parso',
           'Topic :: Software Development :: Libraries :: Python Modules',
           'Topic :: Text Editors :: Integrated Development Environments (IDE)',
           'Topic :: Utilities',
+          'Typing :: Typed',
       ],
       extras_require={
           'testing': [


### PR DESCRIPTION
As well as the type stubs, this includes both the `py.typed` flag file (for tools) and the classifier (for people).

I've manually checked this by installing this against my development `jedi`. Not only does it make the `mypy` run faster, but it also solves a bunch of the errors I was getting. There's one remaining (lack of `parso.python.tree.search_ancestor`), though I'll look at that separately.