### PR TITLE
Properly check for invalid conversion character with f-string debugging syntax

### DIFF
--- a/parso/python/errors.py
+++ b/parso/python/errors.py
@@ -957,7 +957,11 @@ class _FStringRule(SyntaxRule):
         if '\\' in expr.get_code():
             self.add_issue(expr, message=self.message_expr)
 
-        conversion = fstring_expr.children[2]
+        children_2 = fstring_expr.children[2]
+        if children_2.type == 'operator' and children_2.value == '=':
+            conversion = fstring_expr.children[3]
+        else:
+            conversion = children_2
         if conversion.type == 'fstring_conversion':
             name = conversion.children[1]
             if name.value not in ('s', 'r', 'a'):

--- a/test/failing_examples.py
+++ b/test/failing_examples.py
@@ -357,3 +357,7 @@ if sys.version_info[:2] >= (3, 8):
         '(None := 1)',
         '(__debug__ := 1)',
     ]
+    # f-string debugging syntax with invalid conversion character
+    FAILING_EXAMPLES += [
+        "f'{1=!b}'",
+    ]

--- a/test/test_fstring.py
+++ b/test/test_fstring.py
@@ -79,6 +79,7 @@ def test_valid(code, grammar):
 
         # invalid conversion characters
         'f"{1!{a}}"',
+        'f"{1=!{a}}"',
         'f"{!{a}}"',
 
         # The curly braces must contain an expression


### PR DESCRIPTION
When an f-string contains `=` debugging syntax in Python 3.8, the conversion character part may not be located at the position of `fstring_expr.children[2]`, thus its validity (only `!s`, `!r`, `!a` allowed) may not be properly checked. This PR will fix it.