### PR TITLE
Allow some unparenthesized syntactic structures in f-string expression part

### DIFF
--- a/parso/python/grammar310.txt
+++ b/parso/python/grammar310.txt
@@ -167,5 +167,5 @@ strings: (STRING | fstring)+
 fstring: FSTRING_START fstring_content* FSTRING_END
 fstring_content: FSTRING_STRING | fstring_expr
 fstring_conversion: '!' NAME
-fstring_expr: '{' testlist ['='] [ fstring_conversion ] [ fstring_format_spec ] '}'
+fstring_expr: '{' (testlist_comp | yield_expr) ['='] [ fstring_conversion ] [ fstring_format_spec ] '}'
 fstring_format_spec: ':' fstring_content*

--- a/parso/python/grammar36.txt
+++ b/parso/python/grammar36.txt
@@ -154,5 +154,5 @@ strings: (STRING | fstring)+
 fstring: FSTRING_START fstring_content* FSTRING_END
 fstring_content: FSTRING_STRING | fstring_expr
 fstring_conversion: '!' NAME
-fstring_expr: '{' testlist_comp [ fstring_conversion ] [ fstring_format_spec ] '}'
+fstring_expr: '{' (testlist_comp | yield_expr) [ fstring_conversion ] [ fstring_format_spec ] '}'
 fstring_format_spec: ':' fstring_content*

--- a/parso/python/grammar37.txt
+++ b/parso/python/grammar37.txt
@@ -152,5 +152,5 @@ strings: (STRING | fstring)+
 fstring: FSTRING_START fstring_content* FSTRING_END
 fstring_content: FSTRING_STRING | fstring_expr
 fstring_conversion: '!' NAME
-fstring_expr: '{' testlist [ fstring_conversion ] [ fstring_format_spec ] '}'
+fstring_expr: '{' (testlist_comp | yield_expr) [ fstring_conversion ] [ fstring_format_spec ] '}'
 fstring_format_spec: ':' fstring_content*

--- a/parso/python/grammar38.txt
+++ b/parso/python/grammar38.txt
@@ -167,5 +167,5 @@ strings: (STRING | fstring)+
 fstring: FSTRING_START fstring_content* FSTRING_END
 fstring_content: FSTRING_STRING | fstring_expr
 fstring_conversion: '!' NAME
-fstring_expr: '{' testlist ['='] [ fstring_conversion ] [ fstring_format_spec ] '}'
+fstring_expr: '{' (testlist_comp | yield_expr) ['='] [ fstring_conversion ] [ fstring_format_spec ] '}'
 fstring_format_spec: ':' fstring_content*

--- a/parso/python/grammar39.txt
+++ b/parso/python/grammar39.txt
@@ -167,5 +167,5 @@ strings: (STRING | fstring)+
 fstring: FSTRING_START fstring_content* FSTRING_END
 fstring_content: FSTRING_STRING | fstring_expr
 fstring_conversion: '!' NAME
-fstring_expr: '{' testlist ['='] [ fstring_conversion ] [ fstring_format_spec ] '}'
+fstring_expr: '{' (testlist_comp | yield_expr) ['='] [ fstring_conversion ] [ fstring_format_spec ] '}'
 fstring_format_spec: ':' fstring_content*

--- a/test/test_fstring.py
+++ b/test/test_fstring.py
@@ -60,6 +60,13 @@ def grammar():
 
         # a line continuation inside of an format spec
         'f"{123:.2\\\nf}"',
+
+        # some unparenthesized syntactic structures
+        'f"{*x,}"',
+        'f"{*x, *y}"',
+        'f"{x, *y}"',
+        'f"{*x, y}"',
+        'f"{x for x in [1]}"',
     ]
 )
 def test_valid(code, grammar):

--- a/test/test_python_errors.py
+++ b/test/test_python_errors.py
@@ -274,6 +274,8 @@ def test_paren_kwarg():
         r'fr"\""',
         r'fr"\\\""',
         r"print(f'Some {x:.2f} and some {y}')",
+        # Unparenthesized yield expression
+        'def foo(): return f"{yield 1}"',
     ]
 )
 def test_valid_fstrings(code):


### PR DESCRIPTION
Fixes #157, #158