### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: xenial
+arch:
+  - AMD64
+  - ppc64le
 language: python
 python:
   - 3.6
@@ -17,6 +20,25 @@ matrix:
         - 'flake8 --extend-ignore F401 parso test/*.py setup.py scripts/'
         - mypy parso
     - python: 3.8.2
+      script:
+        - 'pip install coverage'
+        - 'coverage run -m pytest'
+        - 'coverage report'
+      after_script:
+          - |
+            pip install --quiet coveralls
+            coveralls
+#Power jobs
+    - python: 3.8
+      arch: ppc64le
+      install:
+        - 'pip install .[qa]'
+      script:
+        # Ignore F401, which are unused imports. flake8 is a primitive tool and is sometimes wrong.
+        - 'flake8 --extend-ignore F401 parso test/*.py setup.py scripts/'
+        - mypy parso
+    - python: 3.8.2
+      arch: ppc64le
       script:
         - 'pip install coverage'
         - 'coverage run -m pytest'


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.