### PR TITLE
Fix various issues regarding starred expressions

### DIFF
--- a/test/failing_examples.py
+++ b/test/failing_examples.py
@@ -145,6 +145,44 @@ FAILING_EXAMPLES = [
     '([False], a) = x',
     'def x(): from math import *',
 
+    # invalid del statements
+    'del x + y',
+    'del x(y)',
+    'async def foo(): del await x',
+    'def foo(): del (yield x)',
+    'del [x for x in range(10)]',
+    'del *x',
+    'del *x,',
+    'del (*x,)',
+    'del [*x]',
+    'del x, *y',
+    'del *x.y,',
+    'del *x[y],',
+    'del *x[y::], z',
+    'del x, (y, *z)',
+    'del (x, *[y, z])',
+    'del [x, *(y, [*z])]',
+    'del {}',
+    'del {x}',
+    'del {x, y}',
+    'del {x, *y}',
+
+    # invalid starred expressions
+    '*x',
+    '(*x)',
+    '((*x))',
+    '1 + (*x)',
+    '*x; 1',
+    '1; *x',
+    '1\n*x',
+    'x = *y',
+    'x: int = *y',
+    'def foo(): return *x',
+    'def foo(): yield *x',
+    'f"{*x}"',
+    'for *x in 1: pass',
+    '[1 for *x in 1]',
+
     # str/bytes combinations
     '"s" b""',
     '"s" b"" ""',
@@ -198,6 +236,9 @@ FAILING_EXAMPLES = [
     '[*[] for a in [1]]',
     'async def bla():\n def x():  await bla()',
     'del None',
+    'del True',
+    'del False',
+    'del ...',
 
     # Errors of global / nonlocal
     dedent('''

--- a/test/test_python_errors.py
+++ b/test/test_python_errors.py
@@ -415,11 +415,32 @@ def test_unparenthesized_genexp(source, no_errors):
         ('*x = 2', False),
         ('(*y) = 1', False),
         ('((*z)) = 1', False),
+        ('*a,', True),
+        ('*a, = 1', True),
+        ('(*a,)', True),
+        ('(*a,) = 1', True),
+        ('[*a]', True),
+        ('[*a] = 1', True),
+        ('a, *b', True),
         ('a, *b = 1', True),
+        ('a, *b, c', True),
         ('a, *b, c = 1', True),
+        ('a, (*b), c', True),
         ('a, (*b), c = 1', True),
+        ('a, ((*b)), c', True),
         ('a, ((*b)), c = 1', True),
+        ('a, (*b, c), d', True),
         ('a, (*b, c), d = 1', True),
+        ('*a.b,', True),
+        ('*a.b, = 1', True),
+        ('*a[b],', True),
+        ('*a[b], = 1', True),
+        ('*a[b::], c', True),
+        ('*a[b::], c = 1', True),
+        ('(a, *[b, c])', True),
+        ('(a, *[b, c]) = 1', True),
+        ('[a, *(b, [*c])]', True),
+        ('[a, *(b, [*c])] = 1', True),
         ('[*(1,2,3)]', True),
         ('{*(1,2,3)}', True),
         ('[*(1,2,3),]', True),
@@ -432,3 +453,35 @@ def test_unparenthesized_genexp(source, no_errors):
 )
 def test_starred_expr(source, no_errors):
     assert bool(_get_error_list(source, version="3")) ^ no_errors
+
+
+@pytest.mark.parametrize(
+    'code', [
+        '() = ()',
+        '() = []',
+        '[] = ()',
+        '[] = []',
+    ]
+)
+def test_valid_empty_assignment(code):
+    assert not _get_error_list(code)
+
+
+@pytest.mark.parametrize(
+    'code', [
+        'del ()',
+        'del []',
+        'del x',
+        'del x,',
+        'del x, y',
+        'del (x, y)',
+        'del [x, y]',
+        'del (x, [y, z])',
+        'del x.y, x[y]',
+        'del f(x)[y::]',
+        'del x[[*y]]',
+        'del x[[*y]::]',
+    ]
+)
+def test_valid_del(code):
+    assert not _get_error_list(code)

--- a/test/test_python_errors.py
+++ b/test/test_python_errors.py
@@ -425,10 +425,6 @@ def test_unparenthesized_genexp(source, no_errors):
         ('a, *b = 1', True),
         ('a, *b, c', True),
         ('a, *b, c = 1', True),
-        ('a, (*b), c', True),
-        ('a, (*b), c = 1', True),
-        ('a, ((*b)), c', True),
-        ('a, ((*b)), c = 1', True),
         ('a, (*b, c), d', True),
         ('a, (*b, c), d = 1', True),
         ('*a.b,', True),
@@ -453,6 +449,19 @@ def test_unparenthesized_genexp(source, no_errors):
 )
 def test_starred_expr(source, no_errors):
     assert bool(_get_error_list(source, version="3")) ^ no_errors
+
+
+@pytest.mark.parametrize(
+    'code', [
+        'a, (*b), c',
+        'a, (*b), c = 1',
+        'a, ((*b)), c',
+        'a, ((*b)), c = 1',
+    ]
+)
+def test_parenthesized_single_starred_expr(code):
+    assert not _get_error_list(code, version='3.8')
+    assert _get_error_list(code, version='3.9')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Properly check for starred expression deletion
- Check for starred expressions not in tuple/list/set (when not in assignment)
- Fix a bug that considered starred expression assignment `[*x] = 1` as invalid
- Parenthesized single starred expression `(*x)` is no longer valid anywhere in Python 3.9+. Therefore `a, (*b), c = [1, 2, 3]` will be invalid in Python 3.9+. See [bpo-40631](https://bugs.python.org/issue40631).
- Enhance test cases for valid and invalid `del` statements and starred expressions

Fixes #166