### PR TITLE
Add type annotations to start- and end-pos attributes

### DIFF
--- a/parso/python/prefix.py
+++ b/parso/python/prefix.py
@@ -1,5 +1,6 @@
 import re
 from codecs import BOM_UTF8
+from typing import Tuple
 
 from parso.python.tokenize import group
 
@@ -13,10 +14,10 @@ class PrefixPart:
         self.type = typ
         self.value = value
         self.spacing = spacing
-        self.start_pos = start_pos
+        self.start_pos = start_pos  # type: Tuple[int, int]
 
     @property
-    def end_pos(self):
+    def end_pos(self) -> Tuple[int, int]:
         if self.value.endswith('\n'):
             return self.start_pos[0] + 1, 0
         if self.value == unicode_bom:

--- a/parso/python/prefix.py
+++ b/parso/python/prefix.py
@@ -14,7 +14,7 @@ class PrefixPart:
         self.type = typ
         self.value = value
         self.spacing = spacing
-        self.start_pos = start_pos  # type: Tuple[int, int]
+        self.start_pos: Tuple[int, int] = start_pos
 
     @property
     def end_pos(self) -> Tuple[int, int]:

--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -47,6 +47,7 @@ try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
+from typing import Tuple
 
 from parso.tree import Node, BaseNode, Leaf, ErrorNode, ErrorLeaf, \
     search_ancestor
@@ -149,7 +150,7 @@ class _LeafWithoutNewlines(PythonLeaf):
     __slots__ = ()
 
     @property
-    def end_pos(self):
+    def end_pos(self) -> Tuple[int, int]:
         return self.line, self.column + len(self.value)
 
 

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -192,7 +192,7 @@ class Leaf(NodeOrLeaf):
         :py:func:`str` Typically a mixture of whitespace and comments. Stuff
         that is syntactically irrelevant for the syntax tree.
         '''
-        self.parent = None  # type: Optional[BaseNode]
+        self.parent: Optional[BaseNode] = None
         '''
         The parent :class:`BaseNode` of this leaf.
         '''
@@ -264,7 +264,7 @@ class BaseNode(NodeOrLeaf):
         """
         A list of :class:`NodeOrLeaf` child nodes.
         """
-        self.parent = None  # type: Optional[BaseNode]
+        self.parent: Optional[BaseNode] = None
         '''
         The parent :class:`BaseNode` of this leaf.
         None if this is the root node.

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod, abstractproperty
+from typing import List, Optional, Tuple
 
 from parso.utils import split_lines
 
@@ -125,7 +126,7 @@ class NodeOrLeaf:
                 return node
 
     @abstractproperty
-    def start_pos(self):
+    def start_pos(self) -> Tuple[int, int]:
         """
         Returns the starting position of the prefix as a tuple, e.g. `(3, 4)`.
 
@@ -133,7 +134,7 @@ class NodeOrLeaf:
         """
 
     @abstractproperty
-    def end_pos(self):
+    def end_pos(self) -> Tuple[int, int]:
         """
         Returns the end position of the prefix as a tuple, e.g. `(3, 4)`.
 
@@ -180,7 +181,7 @@ class Leaf(NodeOrLeaf):
     '''
     __slots__ = ('value', 'parent', 'line', 'column', 'prefix')
 
-    def __init__(self, value, start_pos, prefix=''):
+    def __init__(self, value: str, start_pos: Tuple[int, int], prefix: str = '') -> None:
         self.value = value
         '''
         :py:func:`str` The value of the current token.
@@ -191,17 +192,17 @@ class Leaf(NodeOrLeaf):
         :py:func:`str` Typically a mixture of whitespace and comments. Stuff
         that is syntactically irrelevant for the syntax tree.
         '''
-        self.parent = None
+        self.parent = None  # type: Optional[BaseNode]
         '''
         The parent :class:`BaseNode` of this leaf.
         '''
 
     @property
-    def start_pos(self):
+    def start_pos(self) -> Tuple[int, int]:
         return self.line, self.column
 
     @start_pos.setter
-    def start_pos(self, value):
+    def start_pos(self, value: Tuple[int, int]) -> None:
         self.line = value[0]
         self.column = value[1]
 
@@ -226,7 +227,7 @@ class Leaf(NodeOrLeaf):
             return self.value
 
     @property
-    def end_pos(self):
+    def end_pos(self) -> Tuple[int, int]:
         lines = split_lines(self.value)
         end_pos_line = self.line + len(lines) - 1
         # Check for multiline token
@@ -258,26 +259,26 @@ class BaseNode(NodeOrLeaf):
     """
     __slots__ = ('children', 'parent')
 
-    def __init__(self, children):
+    def __init__(self, children: List[NodeOrLeaf]) -> None:
         self.children = children
         """
         A list of :class:`NodeOrLeaf` child nodes.
         """
-        self.parent = None
+        self.parent = None  # type: Optional[BaseNode]
         '''
         The parent :class:`BaseNode` of this leaf.
         None if this is the root node.
         '''
 
     @property
-    def start_pos(self):
+    def start_pos(self) -> Tuple[int, int]:
         return self.children[0].start_pos
 
     def get_start_pos_of_prefix(self):
         return self.children[0].get_start_pos_of_prefix()
 
     @property
-    def end_pos(self):
+    def end_pos(self) -> Tuple[int, int]:
         return self.children[-1].end_pos
 
     def _get_code_for_children(self, children, include_prefix):

--- a/test/test_normalizer_issues_files.py
+++ b/test/test_normalizer_issues_files.py
@@ -6,6 +6,7 @@ tests of pydocstyle.
 import difflib
 import re
 from functools import total_ordering
+from typing import Iterator, Tuple
 
 import parso
 from parso.utils import python_bytes_to_unicode
@@ -13,7 +14,7 @@ from parso.utils import python_bytes_to_unicode
 
 @total_ordering
 class WantedIssue:
-    def __init__(self, code, line, column):
+    def __init__(self, code: str, line: int, column: int) -> None:
         self.code = code
         self._line = line
         self._column = column
@@ -21,18 +22,18 @@ class WantedIssue:
     def __eq__(self, other):
         return self.code == other.code and self.start_pos == other.start_pos
 
-    def __lt__(self, other):
+    def __lt__(self, other: 'WantedIssue') -> bool:
         return self.start_pos < other.start_pos or self.code < other.code
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(str(self.code) + str(self._line) + str(self._column))
 
     @property
-    def start_pos(self):
+    def start_pos(self) -> Tuple[int, int]:
         return self._line, self._column
 
 
-def collect_errors(code):
+def collect_errors(code: str) -> Iterator[WantedIssue]:
     for line_nr, line in enumerate(code.splitlines(), 1):
         match = re.match(r'(\s*)#: (.*)$', line)
         if match is not None:


### PR DESCRIPTION
These are frequently used within consuming code, so having annotations avoids others needing to work around mypy errors from them.

I've added a small number of other annotations where it made sense to do so, though I've tried to keep this PR limited to just the position attributes.