### PR TITLE
Prevent incorrect syntax error with nonlocal of a parameter

### DIFF
--- a/test/failing_examples.py
+++ b/test/failing_examples.py
@@ -337,6 +337,13 @@ FAILING_EXAMPLES = [
                 def z():
                     nonlocal a
         '''),
+    # Name is assigned before nonlocal declaration
+    dedent('''
+        def x(a):
+            def y():
+                a = 10
+                nonlocal a
+       '''),
 ]
 
 if sys.version_info[:2] >= (3, 7):

--- a/test/normalizer_issue_files/allowed_syntax.py
+++ b/test/normalizer_issue_files/allowed_syntax.py
@@ -113,6 +113,29 @@ def x():
             nonlocal a
 
 
+def x(a):
+    def y():
+        nonlocal a
+
+
+def x(a, b):
+    def y():
+        nonlocal b
+        nonlocal a
+
+
+def x(a):
+    def y():
+        def z():
+            nonlocal a
+
+
+def x():
+    def y(a):
+        def z():
+            nonlocal a
+
+
 a = *args, *args
 error[(*args, *args)] = 3
 *args, *args


### PR DESCRIPTION
Also includes a test for the error "name 'x' is assigned before nonlocal
declaration"

Fixes #175