### PR TITLE
Fix flaky test_cache_last_used_update

### DIFF
--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -146,7 +146,7 @@ def test_cache_last_used_update(diff_cache, use_file_io):
         parse('somecode2', cache=True, path=p, diff_cache=diff_cache)
 
     node_cache_item = next(iter(parser_cache.values()))[p]
-    assert now < node_cache_item.last_used < time.time()
+    assert now <= node_cache_item.last_used <= time.time()
 
 
 @skip_pypy


### PR DESCRIPTION
Sometimes time moves slowly and strict comparison is not enough:

```
>       assert now < node_cache_item.last_used < time.time()
E       assert 1614147958.869299 < 1614147958.869299
E        +  where 1614147958.869299 = <parso.cache._NodeCacheItem object at 0x10456fe80>.last_used
E        +  and   1614147958.869299 = <built-in function time>()
E        +    where <built-in function time> = time.time

test/test_cache.py:149: AssertionError
```

In particular, macOS timings can be a bit coarse.

The test failure is from Apple Silicon M1.