### PR TITLE
Add function to dump parser tree

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ source = parso
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
+    pragma: no cover
+
     # Don't complain about missing debug-only code:
     def __repr__
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ parso.egg-info/
 /.pytest_cache
 test/fuzz-redo.pickle
 /venv/
+/htmlcov/

--- a/docs/docs/parser-tree.rst
+++ b/docs/docs/parser-tree.rst
@@ -47,3 +47,4 @@ Utility
 -------
 
 .. autofunction:: parso.tree.search_ancestor
+.. autofunction:: parso.tree.dump

--- a/docs/docs/parser-tree.rst
+++ b/docs/docs/parser-tree.rst
@@ -47,4 +47,3 @@ Utility
 -------
 
 .. autofunction:: parso.tree.search_ancestor
-.. autofunction:: parso.tree.dump

--- a/parso/parser.py
+++ b/parso/parser.py
@@ -23,7 +23,7 @@ within the statement. This lowers memory usage and cpu time and reduces the
 complexity of the ``Parser`` (there's another parser sitting inside
 ``Statement``, which produces ``Array`` and ``Call``).
 """
-from typing import Dict
+from typing import Dict, Type
 
 from parso import tree
 from parso.pgen2.generator import ReservedString
@@ -110,10 +110,10 @@ class BaseParser:
     When a syntax error occurs, error_recovery() is called.
     """
 
-    node_map: Dict[str, type] = {}
+    node_map: Dict[str, Type[tree.BaseNode]] = {}
     default_node = tree.Node
 
-    leaf_map: Dict[str, type] = {}
+    leaf_map: Dict[str, Type[tree.Leaf]] = {}
     default_leaf = tree.Leaf
 
     def __init__(self, pgen_grammar, start_nonterminal='file_input', error_recovery=False):
@@ -156,8 +156,6 @@ class BaseParser:
             node = self.node_map[nonterminal](children)
         except KeyError:
             node = self.default_node(nonterminal, children)
-        for c in children:
-            c.parent = node
         return node
 
     def convert_leaf(self, type_, value, prefix, start_pos):

--- a/parso/python/errors.py
+++ b/parso/python/errors.py
@@ -5,7 +5,6 @@ import re
 from contextlib import contextmanager
 
 from parso.normalizer import Normalizer, NormalizerConfig, Issue, Rule
-from parso.python.tree import search_ancestor
 from parso.python.tokenize import _get_token_collection
 
 _BLOCK_STMTS = ('if_stmt', 'while_stmt', 'for_stmt', 'try_stmt', 'with_stmt')
@@ -231,7 +230,7 @@ def _any_fstring_error(version, node):
     elif node.type == "fstring":
         return True
     else:
-        return search_ancestor(node, "fstring")
+        return node.search_ancestor("fstring")
 
 
 class _Context:
@@ -1265,7 +1264,7 @@ class _NamedExprRule(_CheckAssignmentRule):
         def search_all_comp_ancestors(node):
             has_ancestors = False
             while True:
-                node = search_ancestor(node, 'testlist_comp', 'dictorsetmaker')
+                node = node.search_ancestor('testlist_comp', 'dictorsetmaker')
                 if node is None:
                     break
                 for child in node.children:

--- a/parso/python/parser.py
+++ b/parso/python/parser.py
@@ -96,8 +96,6 @@ class Parser(BaseParser):
                 # prefixes. Just ignore them.
                 children = [children[0]] + children[2:-1]
             node = self.default_node(nonterminal, children)
-        for c in children:
-            c.parent = node
         return node
 
     def convert_leaf(self, type, value, prefix, start_pos):
@@ -185,8 +183,6 @@ class Parser(BaseParser):
 
         if all_nodes:
             node = tree.PythonErrorNode(all_nodes)
-            for n in all_nodes:
-                n.parent = node
             self.stack[start_index - 1].nodes.append(node)
 
         self.stack[start_index:] = []

--- a/parso/python/pep8.py
+++ b/parso/python/pep8.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 from parso.python.errors import ErrorFinder, ErrorFinderConfig
 from parso.normalizer import Rule
-from parso.python.tree import search_ancestor, Flow, Scope
+from parso.python.tree import Flow, Scope
 
 
 _IMPORT_TYPES = ('import_name', 'import_from')
@@ -124,7 +124,7 @@ class BackslashNode(IndentationNode):
     type = IndentationTypes.BACKSLASH
 
     def __init__(self, config, parent_indentation, containing_leaf, spacing, parent=None):
-        expr_stmt = search_ancestor(containing_leaf, 'expr_stmt')
+        expr_stmt = containing_leaf.search_ancestor('expr_stmt')
         if expr_stmt is not None:
             equals = expr_stmt.children[-2]
 
@@ -724,11 +724,11 @@ class PEP8Normalizer(ErrorFinder):
 
     def add_issue(self, node, code, message):
         if self._previous_leaf is not None:
-            if search_ancestor(self._previous_leaf, 'error_node') is not None:
+            if self._previous_leaf.search_ancestor('error_node') is not None:
                 return
             if self._previous_leaf.type == 'error_leaf':
                 return
-        if search_ancestor(node, 'error_node') is not None:
+        if node.search_ancestor('error_node') is not None:
             return
         if code in (901, 903):
             # 901 and 903 are raised by the ErrorFinder.

--- a/parso/python/prefix.py
+++ b/parso/python/prefix.py
@@ -40,6 +40,14 @@ class PrefixPart:
             self.start_pos
         )
 
+    def search_ancestor(self, *node_types):
+        node = self.parent
+        while node is not None:
+            if node.type in node_types:
+                return node
+            node = node.parent
+        return None
+
 
 _comment = r'#[^\n\r\f]*'
 _backslash = r'\\\r?\n'

--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -49,8 +49,7 @@ except ImportError:
     from collections import Mapping
 from typing import Tuple
 
-from parso.tree import Node, BaseNode, Leaf, ErrorNode, ErrorLeaf, \
-    search_ancestor
+from parso.tree import Node, BaseNode, Leaf, ErrorNode, ErrorLeaf
 from parso.python.prefix import split_prefix
 from parso.utils import split_lines
 
@@ -796,7 +795,7 @@ class WithStmt(Flow):
         return names
 
     def get_test_node_from_name(self, name):
-        node = search_ancestor(name, "with_item")
+        node = name.search_ancestor("with_item")
         if node is None:
             raise ValueError('The name is not actually part of a with statement.')
         return node.children[0]
@@ -1191,7 +1190,7 @@ class Param(PythonBaseNode):
         """
         Returns the function/lambda of a parameter.
         """
-        return search_ancestor(self, 'funcdef', 'lambdef')
+        return self.search_ancestor('funcdef', 'lambdef')
 
     def get_code(self, include_prefix=True, include_comma=True):
         """

--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -549,13 +549,9 @@ class Function(ClassOrFunc):
         super().__init__(children)
         parameters = self.children[2]  # After `def foo`
         parameters_children = parameters.children[1:-1]
-        input_has_param = False
-        for child in parameters_children:
-            if isinstance(child, Param):
-                input_has_param = True
         # If input parameters list already has Param objects, keep it as is;
         # otherwise, convert it to a list of Param objects.
-        if not input_has_param:
+        if not any(isinstance(child, Param) for child in parameters_children):
             parameters.children[1:-1] = _create_params(parameters, parameters_children)
 
     def _get_param_nodes(self):
@@ -660,13 +656,9 @@ class Lambda(Function):
         super(Function, self).__init__(children)
         # Everything between `lambda` and the `:` operator is a parameter.
         parameters_children = self.children[1:-2]
-        input_has_param = False
-        for child in parameters_children:
-            if isinstance(child, Param):
-                input_has_param = True
         # If input children list already has Param objects, keep it as is;
         # otherwise, convert it to a list of Param objects.
-        if not input_has_param:
+        if not any(isinstance(child, Param) for child in parameters_children):
             self.children[1:-2] = _create_params(self, parameters_children)
 
     @property

--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -553,8 +553,6 @@ class Function(ClassOrFunc):
         for child in parameters_children:
             if isinstance(child, Param):
                 input_has_param = True
-                # Fix parent relationship of Param children.
-                child.parent = parameters
         # If input parameters list already has Param objects, keep it as is;
         # otherwise, convert it to a list of Param objects.
         if not input_has_param:
@@ -666,8 +664,6 @@ class Lambda(Function):
         for child in parameters_children:
             if isinstance(child, Param):
                 input_has_param = True
-                # Fix parent relationship of Param children.
-                child.parent = self
         # If input children list already has Param objects, keep it as is;
         # otherwise, convert it to a list of Param objects.
         if not input_has_param:
@@ -1102,8 +1098,6 @@ class Param(PythonBaseNode):
     def __init__(self, children, parent=None):
         super().__init__(children)
         self.parent = parent
-        for child in children:
-            child.parent = self
 
     @property
     def star_count(self):

--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -1100,7 +1100,7 @@ class Param(PythonBaseNode):
     """
     type = 'param'
 
-    def __init__(self, children, parent):
+    def __init__(self, children, parent=None):
         super().__init__(children)
         self.parent = parent
         for child in children:

--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -549,7 +549,17 @@ class Function(ClassOrFunc):
     def __init__(self, children):
         super().__init__(children)
         parameters = self.children[2]  # After `def foo`
-        parameters.children[1:-1] = _create_params(parameters, parameters.children[1:-1])
+        parameters_children = parameters.children[1:-1]
+        input_has_param = False
+        for child in parameters_children:
+            if isinstance(child, Param):
+                input_has_param = True
+                # Fix parent relationship of Param children.
+                child.parent = parameters
+        # If input parameters list already has Param objects, keep it as is;
+        # otherwise, convert it to a list of Param objects.
+        if not input_has_param:
+            parameters.children[1:-1] = _create_params(parameters, parameters_children)
 
     def _get_param_nodes(self):
         return self.children[2].children
@@ -652,7 +662,17 @@ class Lambda(Function):
         # We don't want to call the Function constructor, call its parent.
         super(Function, self).__init__(children)
         # Everything between `lambda` and the `:` operator is a parameter.
-        self.children[1:-2] = _create_params(self, self.children[1:-2])
+        parameters_children = self.children[1:-2]
+        input_has_param = False
+        for child in parameters_children:
+            if isinstance(child, Param):
+                input_has_param = True
+                # Fix parent relationship of Param children.
+                child.parent = self
+        # If input children list already has Param objects, keep it as is;
+        # otherwise, convert it to a list of Param objects.
+        if not input_has_param:
+            self.children[1:-2] = _create_params(self, parameters_children)
 
     @property
     def name(self):

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -17,7 +17,7 @@ def search_ancestor(node: 'NodeOrLeaf', *node_types: str) -> 'Optional[BaseNode]
     """
     warnings.warn("parso.tree.search_ancestor() is deprecated, "
                   "use NodeOrLeaf.search_ancestor() instead", DeprecationWarning)
-    return node.search_ancestor()
+    return node.search_ancestor(*node_types)
 
 
 class NodeOrLeaf:

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, abstractproperty
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from parso.utils import split_lines
 
@@ -372,3 +372,96 @@ class ErrorLeaf(Leaf):
     def __repr__(self):
         return "<%s: %s:%s, %s>" % \
             (type(self).__name__, self.token_type, repr(self.value), self.start_pos)
+
+
+def dump(node: NodeOrLeaf, *, indent: Optional[Union[int, str]] = None) -> str:
+    """
+    Return a formatted dump of the parser tree rooted at ``node``. This is mainly
+    useful for debugging purposes.
+
+    The ``indent`` parameter is interpreted in a similar way as :py:func:`ast.dump`.
+    If ``indent`` is a non-negative integer or string, then the tree will be
+    pretty-printed with that indent level. An indent level of 0, negative, or ``""``
+    will only insert newlines. ``None`` (the default) selects the single line
+    representation. Using a positive integer indent indents that many spaces per
+    level. If ``indent`` is a string (such as ``"\\t"``), that string is used to
+    indent each level.
+
+    :param node: the root of the parser tree to be dumped, can be a node or leaf
+    :param indent: indentation style as described above
+
+    :return: the dump of the parser tree
+
+    >>> print(parso.tree.dump(parso.parse("lambda x, y: x + y"), indent=4))
+    Module([
+        Lambda([
+            Keyword('lambda', (1, 0)),
+            Param([
+                Name('x', (1, 7), prefix=' '),
+                Operator(',', (1, 8)),
+            ], ...),
+            Param([
+                Name('y', (1, 10), prefix=' '),
+            ], ...),
+            Operator(':', (1, 11)),
+            PythonNode('arith_expr', [
+                Name('x', (1, 13), prefix=' '),
+                Operator('+', (1, 15), prefix=' '),
+                Name('y', (1, 17), prefix=' '),
+            ]),
+        ]),
+        EndMarker('', (1, 18)),
+    ])
+
+    """
+    from parso.python.tree import Param
+
+    if indent is None:
+        newline = False
+        indent_string = ''
+    elif isinstance(indent, int):
+        newline = True
+        indent_string = ' ' * indent
+    elif isinstance(indent, str):
+        newline = True
+        indent_string = indent
+    else:
+        raise TypeError(f"expect 'indent' to be int, str or None, got {indent!r}")
+
+    def _format_dump(node: NodeOrLeaf, indent: str = '', top_level: bool = True) -> str:
+        result = ''
+        node_type = type(node).__name__
+        if isinstance(node, Leaf):
+            result += f'{indent}{node_type}('
+            if isinstance(node, ErrorLeaf):
+                result += f'{node.token_type!r}, '
+            elif isinstance(node, TypedLeaf):
+                result += f'{node.type!r}, '
+            result += f'{node.value!r}, {node.start_pos!r}'
+            if node.prefix:
+                result += f', prefix={node.prefix!r}'
+            result += ')'
+        elif isinstance(node, BaseNode):
+            result += f'{indent}{node_type}('
+            if isinstance(node, Node):
+                result += f'{node.type!r}, '
+            result += '['
+            if newline:
+                result += '\n'
+            for child in node.children:
+                result += _format_dump(child, indent=indent + indent_string, top_level=False)
+            result += f'{indent}]'
+            if isinstance(node, Param):
+                # Set a dummy parent for Param. Will be fixed in Function/Lambda constructor.
+                result += ', ...'
+            result += ')'
+        else:
+            raise TypeError(f'unsupported node: {node!r}')
+        if not top_level:
+            if newline:
+                result += ',\n'
+            else:
+                result += ', '
+        return result
+
+    return _format_dump(node)

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -1,4 +1,3 @@
-import warnings
 from abc import abstractmethod, abstractproperty
 from typing import List, Optional, Tuple, Union
 
@@ -15,8 +14,6 @@ def search_ancestor(node: 'NodeOrLeaf', *node_types: str) -> 'Optional[BaseNode]
     :param node: The ancestors of this node will be checked.
     :param node_types: type names that are searched for.
     """
-    warnings.warn("parso.tree.search_ancestor() is deprecated, "
-                  "use NodeOrLeaf.search_ancestor() instead", DeprecationWarning)
     return node.search_ancestor(*node_types)
 
 

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -407,10 +407,10 @@ def dump(node: NodeOrLeaf, *, indent: Optional[Union[int, str]] = None) -> str:
             Param([
                 Name('x', (1, 7), prefix=' '),
                 Operator(',', (1, 8)),
-            ], ...),
+            ]),
             Param([
                 Name('y', (1, 10), prefix=' '),
-            ], ...),
+            ]),
             Operator(':', (1, 11)),
             PythonNode('arith_expr', [
                 Name('x', (1, 13), prefix=' '),
@@ -420,10 +420,7 @@ def dump(node: NodeOrLeaf, *, indent: Optional[Union[int, str]] = None) -> str:
         ]),
         EndMarker('', (1, 18)),
     ])
-
     """
-    from parso.python.tree import Param
-
     if indent is None:
         newline = False
         indent_string = ''
@@ -458,11 +455,7 @@ def dump(node: NodeOrLeaf, *, indent: Optional[Union[int, str]] = None) -> str:
                 result += '\n'
             for child in node.children:
                 result += _format_dump(child, indent=indent + indent_string, top_level=False)
-            result += f'{indent}]'
-            if isinstance(node, Param):
-                # Set a dummy parent for Param. Will be fixed in Function/Lambda constructor.
-                result += ', ...'
-            result += ')'
+            result += f'{indent}])'
         else:
             raise TypeError(f'unsupported node: {node!r}')
         if not top_level:

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -28,6 +28,11 @@ class NodeOrLeaf:
     '''
     The type is a string that typically matches the types of the grammar file.
     '''
+    parent: 'Optional[BaseNode]'
+    '''
+    The parent :class:`BaseNode` of this node or leaf.
+    None if this is the root node.
+    '''
 
     def get_root_node(self):
         """
@@ -266,7 +271,7 @@ class BaseNode(NodeOrLeaf):
         """
         self.parent: Optional[BaseNode] = None
         '''
-        The parent :class:`BaseNode` of this leaf.
+        The parent :class:`BaseNode` of this node.
         None if this is the root node.
         '''
         for child in children:

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -196,7 +196,7 @@ class NodeOrLeaf:
             node = node.parent
         return None
 
-    def dump(self, *, indent: Optional[Union[int, str]] = None) -> str:
+    def dump(self, *, indent: Optional[Union[int, str]] = 4) -> str:
         """
         Returns a formatted dump of the parser tree rooted at this node or leaf. This is
         mainly useful for debugging purposes.
@@ -204,15 +204,16 @@ class NodeOrLeaf:
         The ``indent`` parameter is interpreted in a similar way as :py:func:`ast.dump`.
         If ``indent`` is a non-negative integer or string, then the tree will be
         pretty-printed with that indent level. An indent level of 0, negative, or ``""``
-        will only insert newlines. ``None`` (the default) selects the single line
-        representation. Using a positive integer indent indents that many spaces per
-        level. If ``indent`` is a string (such as ``"\\t"``), that string is used to
-        indent each level.
+        will only insert newlines. ``None`` selects the single line representation.
+        Using a positive integer indent indents that many spaces per level. If
+        ``indent`` is a string (such as ``"\\t"``), that string is used to indent each
+        level.
 
-        :param indent: indentation style as described above
+        :param indent: Indentation style as described above. The default indentation is
+            4 spaces, which yields a pretty-printed dump.
 
         >>> import parso
-        >>> print(parso.parse("lambda x, y: x + y").dump(indent=4))
+        >>> print(parso.parse("lambda x, y: x + y").dump())
         Module([
             Lambda([
                 Keyword('lambda', (1, 0)),

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -269,6 +269,8 @@ class BaseNode(NodeOrLeaf):
         The parent :class:`BaseNode` of this leaf.
         None if this is the root node.
         '''
+        for child in children:
+            child.parent = self
 
     @property
     def start_pos(self) -> Tuple[int, int]:

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -14,7 +14,12 @@ def search_ancestor(node: 'NodeOrLeaf', *node_types: str) -> 'Optional[BaseNode]
     :param node: The ancestors of this node will be checked.
     :param node_types: type names that are searched for.
     """
-    return node.search_ancestor(*node_types)
+    n = node.parent
+    while n is not None:
+        if n.type in node_types:
+            return n
+        n = n.parent
+    return None
 
 
 class NodeOrLeaf:

--- a/parso/tree.py
+++ b/parso/tree.py
@@ -392,6 +392,7 @@ def dump(node: NodeOrLeaf, *, indent: Optional[Union[int, str]] = None) -> str:
 
     :return: the dump of the parser tree
 
+    >>> import parso
     >>> print(parso.tree.dump(parso.parse("lambda x, y: x + y"), indent=4))
     Module([
         Lambda([

--- a/test/test_dump_tree.py
+++ b/test/test_dump_tree.py
@@ -163,3 +163,20 @@ def test_dump_parser_tree_invalid_args():
 
     with pytest.raises(TypeError):
         module.dump(indent=1.1)
+
+
+def test_eval_dump_recovers_parent():
+    module = parse("lambda x, y: x + y")
+    module2 = eval(module.dump())
+    assert module2.parent is None
+    lambda_node = module2.children[0]
+    assert lambda_node.parent is module2
+    assert module2.children[1].parent is module2
+    assert lambda_node.children[0].parent is lambda_node
+    param_node = lambda_node.children[1]
+    assert param_node.parent is lambda_node
+    assert param_node.children[0].parent is param_node
+    assert param_node.children[1].parent is param_node
+    arith_expr_node = lambda_node.children[-1]
+    assert arith_expr_node.parent is lambda_node
+    assert arith_expr_node.children[0].parent is arith_expr_node

--- a/test/test_dump_tree.py
+++ b/test/test_dump_tree.py
@@ -6,7 +6,7 @@ from parso import parse
 # Using star import for easier eval testing below.
 from parso.python.tree import *  # noqa: F403
 from parso.tree import *  # noqa: F403
-from parso.tree import ErrorLeaf, TypedLeaf, dump
+from parso.tree import ErrorLeaf, TypedLeaf
 
 
 @pytest.mark.parametrize(
@@ -95,7 +95,7 @@ from parso.tree import ErrorLeaf, TypedLeaf, dump
 def test_dump_parser_tree(indent, expected_dump):
     code = "lambda x, y: x + y"
     module = parse(code)
-    assert dump(module, indent=indent) == expected_dump
+    assert module.dump(indent=indent) == expected_dump
 
     # Check that dumped tree can be eval'd to recover the parser tree and original code.
     recovered_code = eval(expected_dump).get_code()
@@ -150,7 +150,7 @@ def test_dump_parser_tree(indent, expected_dump):
     ]
 )
 def test_dump_parser_tree_not_top_level_module(node, expected_dump, expected_code):
-    dump_result = dump(node)
+    dump_result = node.dump()
     assert dump_result == expected_dump
 
     # Check that dumped tree can be eval'd to recover the parser tree and original code.
@@ -162,7 +162,4 @@ def test_dump_parser_tree_invalid_args():
     module = parse("lambda x, y: x + y")
 
     with pytest.raises(TypeError):
-        dump(module, indent=1.1)
-
-    with pytest.raises(TypeError):
-        dump(1)
+        module.dump(indent=1.1)

--- a/test/test_dump_tree.py
+++ b/test/test_dump_tree.py
@@ -105,31 +105,31 @@ def test_dump_parser_tree(indent, expected_dump):
 @pytest.mark.parametrize(
     'node,expected_dump,expected_code', [
         (  # Dump intermediate node (not top level module)
-            parse("def foo(x, y): return x + y").children[0],
-            "Function(["
-            "Keyword('def', (1, 0)), "
-            "Name('foo', (1, 4), prefix=' '), "
-            "PythonNode('parameters', ["
-            "Operator('(', (1, 7)), "
-            "Param(["
-            "Name('x', (1, 8)), "
-            "Operator(',', (1, 9)), "
-            "]), "
-            "Param(["
-            "Name('y', (1, 11), prefix=' '), "
-            "]), "
-            "Operator(')', (1, 12)), "
-            "]), "
-            "Operator(':', (1, 13)), "
-            "ReturnStmt(["
-            "Keyword('return', (1, 15), prefix=' '), "
-            "PythonNode('arith_expr', ["
-            "Name('x', (1, 22), prefix=' '), "
-            "Operator('+', (1, 24), prefix=' '), "
-            "Name('y', (1, 26), prefix=' '), "
-            "]), "
-            "]), "
-            "])",
+            parse("def foo(x, y): return x + y").children[0], dedent('''\
+                Function([
+                    Keyword('def', (1, 0)),
+                    Name('foo', (1, 4), prefix=' '),
+                    PythonNode('parameters', [
+                        Operator('(', (1, 7)),
+                        Param([
+                            Name('x', (1, 8)),
+                            Operator(',', (1, 9)),
+                        ]),
+                        Param([
+                            Name('y', (1, 11), prefix=' '),
+                        ]),
+                        Operator(')', (1, 12)),
+                    ]),
+                    Operator(':', (1, 13)),
+                    ReturnStmt([
+                        Keyword('return', (1, 15), prefix=' '),
+                        PythonNode('arith_expr', [
+                            Name('x', (1, 22), prefix=' '),
+                            Operator('+', (1, 24), prefix=' '),
+                            Name('y', (1, 26), prefix=' '),
+                        ]),
+                    ]),
+                ])'''),
             "def foo(x, y): return x + y",
         ),
         (  # Dump leaf

--- a/test/test_dump_tree.py
+++ b/test/test_dump_tree.py
@@ -1,0 +1,167 @@
+from textwrap import dedent
+
+import pytest
+
+from parso import parse
+from parso.python.tree import *  # noqa: F403
+from parso.tree import *  # noqa: F403
+from parso.tree import ErrorLeaf, TypedLeaf, dump
+
+
+@pytest.mark.parametrize(
+    'indent,expected_dump', [
+        (None, "Module(["
+               "Lambda(["
+               "Keyword('lambda', (1, 0)), "
+               "Param(["
+               "Name('x', (1, 7), prefix=' '), "
+               "Operator(',', (1, 8)), "
+               "], ...), "
+               "Param(["
+               "Name('y', (1, 10), prefix=' '), "
+               "], ...), "
+               "Operator(':', (1, 11)), "
+               "PythonNode('arith_expr', ["
+               "Name('x', (1, 13), prefix=' '), "
+               "Operator('+', (1, 15), prefix=' '), "
+               "Name('y', (1, 17), prefix=' '), "
+               "]), "
+               "]), "
+               "EndMarker('', (1, 18)), "
+               "])"),
+        (0, dedent('''\
+            Module([
+            Lambda([
+            Keyword('lambda', (1, 0)),
+            Param([
+            Name('x', (1, 7), prefix=' '),
+            Operator(',', (1, 8)),
+            ], ...),
+            Param([
+            Name('y', (1, 10), prefix=' '),
+            ], ...),
+            Operator(':', (1, 11)),
+            PythonNode('arith_expr', [
+            Name('x', (1, 13), prefix=' '),
+            Operator('+', (1, 15), prefix=' '),
+            Name('y', (1, 17), prefix=' '),
+            ]),
+            ]),
+            EndMarker('', (1, 18)),
+            ])''')),
+        (4, dedent('''\
+            Module([
+                Lambda([
+                    Keyword('lambda', (1, 0)),
+                    Param([
+                        Name('x', (1, 7), prefix=' '),
+                        Operator(',', (1, 8)),
+                    ], ...),
+                    Param([
+                        Name('y', (1, 10), prefix=' '),
+                    ], ...),
+                    Operator(':', (1, 11)),
+                    PythonNode('arith_expr', [
+                        Name('x', (1, 13), prefix=' '),
+                        Operator('+', (1, 15), prefix=' '),
+                        Name('y', (1, 17), prefix=' '),
+                    ]),
+                ]),
+                EndMarker('', (1, 18)),
+            ])''')),
+        ('\t', dedent('''\
+            Module([
+            \tLambda([
+            \t\tKeyword('lambda', (1, 0)),
+            \t\tParam([
+            \t\t\tName('x', (1, 7), prefix=' '),
+            \t\t\tOperator(',', (1, 8)),
+            \t\t], ...),
+            \t\tParam([
+            \t\t\tName('y', (1, 10), prefix=' '),
+            \t\t], ...),
+            \t\tOperator(':', (1, 11)),
+            \t\tPythonNode('arith_expr', [
+            \t\t\tName('x', (1, 13), prefix=' '),
+            \t\t\tOperator('+', (1, 15), prefix=' '),
+            \t\t\tName('y', (1, 17), prefix=' '),
+            \t\t]),
+            \t]),
+            \tEndMarker('', (1, 18)),
+            ])''')),
+    ]
+)
+def test_dump_parser_tree(indent, expected_dump):
+    code = "lambda x, y: x + y"
+    module = parse(code)
+    assert dump(module, indent=indent) == expected_dump
+
+    # Check that dumped tree can be eval'd to recover the parser tree and original code.
+    recovered_code = eval(expected_dump).get_code()
+    assert recovered_code == code
+
+
+@pytest.mark.parametrize(
+    'node,expected_dump,expected_code', [
+        (  # Dump intermediate node (not top level module)
+            parse("def foo(x, y): return x + y").children[0],
+            "Function(["
+            "Keyword('def', (1, 0)), "
+            "Name('foo', (1, 4), prefix=' '), "
+            "PythonNode('parameters', ["
+            "Operator('(', (1, 7)), "
+            "Param(["
+            "Name('x', (1, 8)), "
+            "Operator(',', (1, 9)), "
+            "], ...), "
+            "Param(["
+            "Name('y', (1, 11), prefix=' '), "
+            "], ...), "
+            "Operator(')', (1, 12)), "
+            "]), "
+            "Operator(':', (1, 13)), "
+            "ReturnStmt(["
+            "Keyword('return', (1, 15), prefix=' '), "
+            "PythonNode('arith_expr', ["
+            "Name('x', (1, 22), prefix=' '), "
+            "Operator('+', (1, 24), prefix=' '), "
+            "Name('y', (1, 26), prefix=' '), "
+            "]), "
+            "]), "
+            "])",
+            "def foo(x, y): return x + y",
+        ),
+        (  # Dump leaf
+            parse("def foo(x, y): return x + y").children[0].children[0],
+            "Keyword('def', (1, 0))",
+            'def',
+        ),
+        (  # Dump ErrorLeaf
+            ErrorLeaf('error_type', 'error_code', (1, 1), prefix=' '),
+            "ErrorLeaf('error_type', 'error_code', (1, 1), prefix=' ')",
+            ' error_code',
+        ),
+        (  # Dump TypedLeaf
+            TypedLeaf('type', 'value', (1, 1)),
+            "TypedLeaf('type', 'value', (1, 1))",
+            'value',
+        ),
+    ]
+)
+def test_dump_parser_tree_not_top_level_module(node, expected_dump, expected_code):
+    dump_result = dump(node)
+    assert dump_result == expected_dump
+
+    # Check that dumped tree can be eval'd to recover the parser tree and original code.
+    recovered_code = eval(dump_result).get_code()
+    assert recovered_code == expected_code
+
+
+def test_dump_parser_tree_invalid_args():
+    module = parse("lambda x, y: x + y")
+
+    with pytest.raises(TypeError):
+        dump(module, indent=1.1)
+
+    with pytest.raises(TypeError):
+        dump(1)

--- a/test/test_dump_tree.py
+++ b/test/test_dump_tree.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 import pytest
 
 from parso import parse
+# Using star import for easier eval testing below.
 from parso.python.tree import *  # noqa: F403
 from parso.tree import *  # noqa: F403
 from parso.tree import ErrorLeaf, TypedLeaf, dump

--- a/test/test_dump_tree.py
+++ b/test/test_dump_tree.py
@@ -17,10 +17,10 @@ from parso.tree import ErrorLeaf, TypedLeaf, dump
                "Param(["
                "Name('x', (1, 7), prefix=' '), "
                "Operator(',', (1, 8)), "
-               "], ...), "
+               "]), "
                "Param(["
                "Name('y', (1, 10), prefix=' '), "
-               "], ...), "
+               "]), "
                "Operator(':', (1, 11)), "
                "PythonNode('arith_expr', ["
                "Name('x', (1, 13), prefix=' '), "
@@ -37,10 +37,10 @@ from parso.tree import ErrorLeaf, TypedLeaf, dump
             Param([
             Name('x', (1, 7), prefix=' '),
             Operator(',', (1, 8)),
-            ], ...),
+            ]),
             Param([
             Name('y', (1, 10), prefix=' '),
-            ], ...),
+            ]),
             Operator(':', (1, 11)),
             PythonNode('arith_expr', [
             Name('x', (1, 13), prefix=' '),
@@ -57,10 +57,10 @@ from parso.tree import ErrorLeaf, TypedLeaf, dump
                     Param([
                         Name('x', (1, 7), prefix=' '),
                         Operator(',', (1, 8)),
-                    ], ...),
+                    ]),
                     Param([
                         Name('y', (1, 10), prefix=' '),
-                    ], ...),
+                    ]),
                     Operator(':', (1, 11)),
                     PythonNode('arith_expr', [
                         Name('x', (1, 13), prefix=' '),
@@ -77,10 +77,10 @@ from parso.tree import ErrorLeaf, TypedLeaf, dump
             \t\tParam([
             \t\t\tName('x', (1, 7), prefix=' '),
             \t\t\tOperator(',', (1, 8)),
-            \t\t], ...),
+            \t\t]),
             \t\tParam([
             \t\t\tName('y', (1, 10), prefix=' '),
-            \t\t], ...),
+            \t\t]),
             \t\tOperator(':', (1, 11)),
             \t\tPythonNode('arith_expr', [
             \t\t\tName('x', (1, 13), prefix=' '),
@@ -114,10 +114,10 @@ def test_dump_parser_tree(indent, expected_dump):
             "Param(["
             "Name('x', (1, 8)), "
             "Operator(',', (1, 9)), "
-            "], ...), "
+            "]), "
             "Param(["
             "Name('y', (1, 11), prefix=' '), "
-            "], ...), "
+            "]), "
             "Operator(')', (1, 12)), "
             "]), "
             "Operator(':', (1, 13)), "

--- a/test/test_parser_tree.py
+++ b/test/test_parser_tree.py
@@ -263,6 +263,6 @@ sample_leaf = sample_node.children[0]
 )
 def test_search_ancestor(node, node_types, expected_ancestor):
     assert node.search_ancestor(*node_types) is expected_ancestor
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         ancestor = search_ancestor(node, *node_types)
     assert ancestor is expected_ancestor

--- a/test/test_parser_tree.py
+++ b/test/test_parser_tree.py
@@ -263,6 +263,4 @@ sample_leaf = sample_node.children[0]
 )
 def test_search_ancestor(node, node_types, expected_ancestor):
     assert node.search_ancestor(*node_types) is expected_ancestor
-    with pytest.deprecated_call():
-        ancestor = search_ancestor(node, *node_types)
-    assert ancestor is expected_ancestor
+    assert search_ancestor(node, *node_types) is expected_ancestor  # deprecated

--- a/test/test_parser_tree.py
+++ b/test/test_parser_tree.py
@@ -6,6 +6,7 @@ import pytest
 
 from parso import parse
 from parso.python import tree
+from parso.tree import search_ancestor
 
 
 class TestsFunctionAndLambdaParsing:
@@ -239,3 +240,29 @@ def test_with_stmt_get_test_node_from_name():
         for name in with_stmt.get_defined_names(include_setitem=True)
     ]
     assert tests == ["A", "B", "C", "D"]
+
+
+sample_module = parse('x + y')
+sample_node = sample_module.children[0]
+sample_leaf = sample_node.children[0]
+
+
+@pytest.mark.parametrize(
+    'node,node_types,expected_ancestor', [
+        (sample_module, ('file_input',), None),
+        (sample_node, ('arith_expr',), None),
+        (sample_node, ('file_input', 'eval_input'), sample_module),
+        (sample_leaf, ('name',), None),
+        (sample_leaf, ('arith_expr',), sample_node),
+        (sample_leaf, ('file_input',), sample_module),
+        (sample_leaf, ('file_input', 'arith_expr'), sample_node),
+        (sample_leaf, ('shift_expr',), None),
+        (sample_leaf, ('name', 'shift_expr',), None),
+        (sample_leaf, (), None),
+    ]
+)
+def test_search_ancestor(node, node_types, expected_ancestor):
+    assert node.search_ancestor(*node_types) is expected_ancestor
+    with pytest.warns(DeprecationWarning):
+        ancestor = search_ancestor(node, *node_types)
+    assert ancestor is expected_ancestor


### PR DESCRIPTION
Add `parso.tree.dump` function to dump the parser tree (implement #113). The design mimics [`ast.dump`](https://docs.python.org/3/library/ast.html#ast.dump). Specifying `indent=4` will produce a readable format, while `indent=None` will produce a single-line compact representation. The produced dump can be `eval`'d back into a valid parso node object, which may be helpful for debugging in interactive REPL.

A sample dump:

```python
>>> import parso
>>> module = parso.parse('lambda x, y: x + y')
>>> print(repr(module))  # cannot see full children information via repr()
<Module: @1-1>
>>> print(parso.tree.dump(module, indent=4))  # full information dumped
Module([
    Lambda([
        Keyword('lambda', (1, 0)),
        Param([
            Name('x', (1, 7), prefix=' '),
            Operator(',', (1, 8)),
        ]),
        Param([
            Name('y', (1, 10), prefix=' '),
        ]),
        Operator(':', (1, 11)),
        PythonNode('arith_expr', [
            Name('x', (1, 13), prefix=' '),
            Operator('+', (1, 15), prefix=' '),
            Name('y', (1, 17), prefix=' '),
        ]),
    ]),
    EndMarker('', (1, 18)),
])
```

A number of small changes are made to make the dump fully "round-trip" (i.e. `eval(dump(node))` recovers the `node`):
- `Function` and `Lambda` node constructors are slightly modified to accept a `children` list which already contains `Param` objects (so that we don't need to process them with `_create_params` again).
- The `parent` argument of the `Param` node constructor becomes optional (to make generating round-trippable dumps easier).
- In `BaseNode` constructor, set all children's parent to `self` (to fix the parent relationship when we construct a new parse tree from the dump).

Question: Should we export this function just as `parso.tree.dump` or even `parso.dump`? And what about exporting `parso.tree.search_ancestor` as `parso.search_ancestor`?