### PR TITLE
Removing state pollution in `parser_cache`

### DIFF
--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -185,7 +185,9 @@ def test_permission_error(monkeypatch):
     was_called = False
 
     monkeypatch.setattr(cache, '_save_to_file_system', save)
-    with pytest.warns(Warning):
-        parse(path=__file__, cache=True, diff_cache=True)
-    assert was_called
-    parser_cache.clear()
+    try:
+        with pytest.warns(Warning):
+            parse(path=__file__, cache=True, diff_cache=True)
+        assert was_called
+    finally:
+        parser_cache.clear()

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -188,3 +188,4 @@ def test_permission_error(monkeypatch):
     with pytest.warns(Warning):
         parse(path=__file__, cache=True, diff_cache=True)
     assert was_called
+    parser_cache.clear()


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_permission_error` by removing state pollution in `parser_cache` by calling method `clear`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test/test_ljson_mem.py::test_unique_check`:

```
        monkeypatch.setattr(cache, '_save_to_file_system', save)
        with pytest.warns(Warning):
>           parse(path=__file__, cache=True, diff_cache=True)
E           Failed: DID NOT WARN. No warnings of type (<class 'Warning'>,) was emitted. The list of emitted warnings is: [].
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
