### PR TITLE
Update cache.py(fix 'WindowsPath' object has no attribute 'expanduser')

### DIFF
--- a/parso/cache.py
+++ b/parso/cache.py
@@ -64,13 +64,14 @@ See: http://docs.python.org/3/library/sys.html#sys.implementation
 
 
 def _get_default_cache_path():
+    # fix 'WindowsPath' object has no attribute 'expanduser'
     if platform.system().lower() == 'windows':
         dir_ = Path(os.getenv('LOCALAPPDATA') or '~', 'Parso', 'Parso')
     elif platform.system().lower() == 'darwin':
-        dir_ = Path('~', 'Library', 'Caches', 'Parso')
+        dir_ = Path('~', 'Library', 'Caches', 'Parso').expanduser()
     else:
-        dir_ = Path(os.getenv('XDG_CACHE_HOME') or '~/.cache', 'parso')
-    return dir_.expanduser()
+        dir_ = Path(os.getenv('XDG_CACHE_HOME') or '~/.cache', 'parso').expanduser()
+    return dir_
 
 
 _default_cache_path = _get_default_cache_path()


### PR DESCRIPTION
fix 'WindowsPath' object has no attribute 'expanduser'

when I start ipython in windows11, will cause the errors below:
(base) C:\Users\kv183>ipython
Traceback (most recent call last):
  File "D:\Program\Miniconda3\Scripts\ipython-script.py", line 6, in <module>
    from IPython import start_ipython
  File "D:\Program\Miniconda3\lib\site-packages\IPython\__init__.py", line 56, in <module>
    from .terminal.embed import embed
......
  File "D:\Program\Miniconda3\lib\site-packages\parso\cache.py", line 76, in <module>
    _default_cache_path = _get_default_cache_path()
  File "D:\Program\Miniconda3\lib\site-packages\parso\cache.py", line 73, in _get_default_cache_path
    return dir_.expanduser()
AttributeError: 'WindowsPath' object has no attribute 'expanduser'

because the Path class in windows doesn't has the funciton named 'expanduser'