### PR TITLE
Fixes `__slots__` definition in `NodeOrLeaf`

### DIFF
--- a/parso/tree.py
+++ b/parso/tree.py
@@ -26,7 +26,7 @@ class NodeOrLeaf:
     """
     The base class for nodes and leaves.
     """
-    __slots__ = ()
+    __slots__ = ('parent',)
     type: str
     '''
     The type is a string that typically matches the types of the grammar file.
@@ -290,7 +290,7 @@ class Leaf(NodeOrLeaf):
     Leafs are basically tokens with a better API. Leafs exactly know where they
     were defined and what text preceeds them.
     '''
-    __slots__ = ('value', 'parent', 'line', 'column', 'prefix')
+    __slots__ = ('value', 'line', 'column', 'prefix')
     prefix: str
 
     def __init__(self, value: str, start_pos: Tuple[int, int], prefix: str = '') -> None:
@@ -369,7 +369,7 @@ class BaseNode(NodeOrLeaf):
     The super class for all nodes.
     A node has children, a type and possibly a parent node.
     """
-    __slots__ = ('children', 'parent')
+    __slots__ = ('children',)
 
     def __init__(self, children: List[NodeOrLeaf]) -> None:
         self.children = children


### PR DESCRIPTION
This place: 
https://github.com/davidhalter/parso/blob/ae491cbf55853abf9c2cf3ab36ed1b9adc46384e/parso/tree.py#L385
uses `.parent` assignment on `NodeOrLeaf` type. While, `parent` was not in `__slots__` of `NodeOrLeaf`. But in `__slots__` of both its children: `Leaf` and `BaseNode`.

Identified by https://github.com/python/mypy/pull/10864