### PR TITLE
Add missing slots to base classes

### DIFF
--- a/parso/python/tree.py
+++ b/parso/python/tree.py
@@ -295,6 +295,8 @@ class FStringEnd(PythonLeaf):
 
 
 class _StringComparisonMixin:
+    __slots__ = ()
+
     def __eq__(self, other):
         """
         Make comparisons with strings easy.
@@ -544,6 +546,7 @@ class Function(ClassOrFunc):
         4. annotation (if present)
     """
     type = 'funcdef'
+    __slots__ = ()
 
     def __init__(self, children):
         super().__init__(children)


### PR DESCRIPTION
The effectiveness of `__slots__` is reduced if they are missing in base classes. This was the case for a few classes in `parso`:

```
$ slotscheck parso
ERROR: 'parso.python.tree:Keyword' has slots but superclass does not.
ERROR: 'parso.python.tree:Lambda' has slots but superclass does not.
ERROR: 'parso.python.tree:Operator' has slots but superclass does not.
Oh no, found some problems!
Scanned 21 module(s), 136 class(es).
```

The fix appears easy. All tests seem to pass.

I discovered the slots issues with [slotscheck](https://github.com/ariebovenberg/slotscheck), a tool I maintain. Of course, If you like, I can add it to CI as I've done for [instagram/LibCST](https://github.com/Instagram/LibCST/pull/615), [sqlalchemy/sqlalchemy](https://github.com/sqlalchemy/sqlalchemy/pull/7670), and [aio-libs/aiohttp](https://github.com/aio-libs/aiohttp/pull/6547).
