### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/parso/grammar.py
+++ b/parso/grammar.py
@@ -47,15 +47,15 @@ class Grammar(Generic[_NodeT]):
         self._hashed = hashlib.sha256(text.encode("utf-8")).hexdigest()
 
     def parse(self,
-              code: Union[str, bytes] = None,
+              code: Optional[Union[str, bytes]] = None,
               *,
               error_recovery=True,
-              path: Union[os.PathLike, str] = None,
-              start_symbol: str = None,
+              path: Optional[Union[os.PathLike, str]] = None,
+              start_symbol: Optional[str] = None,
               cache=False,
               diff_cache=False,
-              cache_path: Union[os.PathLike, str] = None,
-              file_io: FileIO = None) -> _NodeT:
+              cache_path: Optional[Union[os.PathLike, str]] = None,
+              file_io: Optional[FileIO] = None) -> _NodeT:
         """
         If you want to parse a Python file you want to start here, most likely.
 
@@ -231,7 +231,7 @@ class PythonGrammar(Grammar):
         return tokenize(code, version_info=self.version_info)
 
 
-def load_grammar(*, version: str = None, path: str = None):
+def load_grammar(*, version: Optional[str] = None, path: Optional[str] = None):
     """
     Loads a :py:class:`parso.Grammar`. The default version is the current Python
     version.

--- a/parso/python/tokenize.py
+++ b/parso/python/tokenize.py
@@ -15,8 +15,8 @@ import sys
 import re
 import itertools as _itertools
 from codecs import BOM_UTF8
-from typing import NamedTuple, Tuple, Iterator, Iterable, List, Dict, \
-    Pattern, Set
+from typing import NamedTuple, Tuple, Iterator, Iterable, List, Dict \
+    Pattern, Set, Optional
 
 from parso.python.token import PythonTokenTypes
 from parso.utils import split_lines, PythonVersionInfo, parse_version_string
@@ -364,7 +364,7 @@ def tokenize_lines(
     lines: Iterable[str],
     *,
     version_info: PythonVersionInfo,
-    indents: List[int] = None,
+    indents: Optional[List[int]] = None,
     start_pos: Tuple[int, int] = (1, 0),
     is_first_token=True,
 ) -> Iterator[PythonToken]:

--- a/parso/python/tokenize.py
+++ b/parso/python/tokenize.py
@@ -15,7 +15,7 @@ import sys
 import re
 import itertools as _itertools
 from codecs import BOM_UTF8
-from typing import NamedTuple, Tuple, Iterator, Iterable, List, Dict \
+from typing import NamedTuple, Tuple, Iterator, Iterable, List, Dict, \
     Pattern, Set, Optional
 
 from parso.python.token import PythonTokenTypes

--- a/parso/utils.py
+++ b/parso/utils.py
@@ -2,7 +2,7 @@ import re
 import sys
 from ast import literal_eval
 from functools import total_ordering
-from typing import NamedTuple, Sequence, Union
+from typing import Optional, NamedTuple, Sequence, Union
 
 # The following is a list in Python that are line breaks in str.splitlines, but
 # not in Python. In Python only \r (Carriage Return, 0xD) and \n (Line Feed,
@@ -180,7 +180,7 @@ def _parse_version(version) -> PythonVersionInfo:
     return PythonVersionInfo(major, minor)
 
 
-def parse_version_string(version: str = None) -> PythonVersionInfo:
+def parse_version_string(version: Optional[str] = None) -> PythonVersionInfo:
     """
     Checks for a valid version number (e.g. `3.8` or `3.10.1` or `3`) and
     returns a corresponding version info that is always two characters long in

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ warn_unused_configs = True
 warn_unreachable = True
 
 strict_equality = True
+no_implicit_optional = True

--- a/test/normalizer_issue_files/python.py
+++ b/test/normalizer_issue_files/python.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import ClassVar, List
+from typing import Optional, ClassVar, List
 
 print(1, 2)
 
@@ -62,8 +62,8 @@ a[b1, :] == a[b1, ...]
 
 # Annotated Function Definitions
 # Okay
-def munge(input: AnyStr, sep: AnyStr = None, limit=1000,
-          extra: Union[str, dict] = None) -> AnyStr:
+def munge(input: AnyStr, sep: Optional[AnyStr] = None, limit=1000,
+          extra: Optional[Union[str, dict]] = None) -> AnyStr:
     pass
 
 


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/hauntsaninja/no_implicit_optional
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401