### PR TITLE
Explicitly allow implicit optionals

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ warn_unused_configs = True
 warn_unreachable = True
 
 strict_equality = True
+no_implicit_optional = False


### PR DESCRIPTION
Keeps things working when you upgrade mypy versions. The other way of solving this problem is in #208