### PR TITLE
Fix #224: Remove Potential Malicious Link in Parso's Acknowledgement README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,8 +88,7 @@ Acknowledgements
 
 - Guido van Rossum (@gvanrossum) for creating the parser generator pgen2
   (originally used in lib2to3).
-- `Salome Schneider <https://www.crepes-schnaegg.ch/cr%C3%AApes-schn%C3%A4gg/kunst-f%C3%BCrs-cr%C3%AApes-mobil/>`_
-  for the extremely awesome parso logo.
+- Salome Schneider for the extremely awesome parso logo.
 
 
 .. _jedi: https://github.com/davidhalter/jedi


### PR DESCRIPTION
## Description

This pull request addresses issue #224 by removing the potentially malicious link from the Acknowledgements section of the `README.rst`. The link in question was flagged by internal IT as suspicious and has been excluded to ensure the safety and integrity of the `parso` package.

### Additional Research:

- I'm not a security specialist, but a quick who.is search on the domain provided limited information.
![who is_diagnostics](https://github.com/davidhalter/parso/assets/104395997/8156880d-b5f9-4360-a917-ececb951376d)
![who is_DNS_Records](https://github.com/davidhalter/parso/assets/104395997/5f07087e-9be8-4e25-af98-05a9a8cbe5eb)
![who is_search](https://github.com/davidhalter/parso/assets/104395997/ce6f9ec2-cb79-4045-b017-f2d3ebeb4142)


### Changes Made:

- Removed the following link from the `README.rst`:
Salome Schneider https://www.crepes-schnaegg.ch/cr%C3%AApes-schn%C3%A4gg/kunst-f%C3%BCrs-cr%C3%AApes-mobil/

### Verification:

Since it appears that the `METADATA` file may be generated from the `README.rst` during the installation process, it is expected that the link will no longer appear in the `METADATA` file after installing the updated version of `parso`. To verify this, please install the updated package in a virtual environment and confirm that the `METADATA` file does not contain the removed link.

### Additional Notes:

- The link was removed from the `README.rst` with the expectation that it will not be present in the generated `METADATA` file.
- If there are any concerns or if further validation is needed, please let me know.

### Reviewers:

@davidhalter - Could you please review these changes?

Thank you for your attention to this matter.