### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
     steps:
     - uses: actions/checkout@v2

--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@ from parso.utils import parse_version_string
 
 collect_ignore = ["setup.py"]
 
-_SUPPORTED_VERSIONS = '3.6', '3.7', '3.8', '3.9', '3.10'
+_SUPPORTED_VERSIONS = '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14'
 
 
 @pytest.fixture(scope='session')

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Editors :: Integrated Development Environments (IDE)',
         'Topic :: Utilities',


### PR DESCRIPTION
It seems 3.7 is breaking CI... it's also ~2 years past EOL. It's probably OK to remove it from CI.

I then checked other files for mentions of 3.7 and found 2 places that weren't up to date. Hopefully they're fine to update. I didn't remove any code adding support for testing 3.7 because... well... I don't know, that seems out of scope.